### PR TITLE
Fix tracer maxstateint

### DIFF
--- a/src/dr/app/tools/AntigenicPlotter.java
+++ b/src/dr/app/tools/AntigenicPlotter.java
@@ -107,7 +107,7 @@ public class AntigenicPlotter {
             traces.loadTraces();
 
             if (burnin == -1) {
-                burnin = traces.getMaxState() / 10;
+                burnin = (int) (traces.getMaxState() / 10);
             }
 
             traces.setBurnIn(burnin);

--- a/src/dr/app/tracer/traces/CombinedTraces.java
+++ b/src/dr/app/tracer/traces/CombinedTraces.java
@@ -138,7 +138,7 @@ public class CombinedTraces extends FilteredTraceList { //implements TraceList {
     /**
      * @return the last state in the chain
      */
-    public int getMaxState() {
+    public long getMaxState() {
         return getStateCount() * getStepSize();
     }
 

--- a/src/dr/evomodelxml/TreeWorkingPriorParsers.java
+++ b/src/dr/evomodelxml/TreeWorkingPriorParsers.java
@@ -243,10 +243,10 @@ public class TreeWorkingPriorParsers {
 
                 LogFileTraces traces = new LogFileTraces(fileName, file);
                 traces.loadTraces();
-                int maxState = traces.getMaxState();
+                long maxState = traces.getMaxState();
 
                 // leaving the burnin attribute off will result in 10% being used
-                int burnin = xo.getAttribute("burnin", maxState / 10);
+                long burnin = xo.getAttribute("burnin", maxState / 10);
                 if (burnin < 0 || burnin >= maxState) {
                     burnin = maxState / 10;
                     System.out.println("WARNING: Burn-in larger than total number of states - using 10%");
@@ -347,10 +347,10 @@ public class TreeWorkingPriorParsers {
 
                 LogFileTraces traces = new LogFileTraces(fileName, file);
                 traces.loadTraces();
-                int maxState = traces.getMaxState();
+                long maxState = traces.getMaxState();
 
                 // leaving the burnin attribute off will result in 10% being used
-                int burnin = xo.getAttribute("burnin", maxState / 10);
+                long burnin = xo.getAttribute("burnin", maxState / 10);
                 if (burnin < 0 || burnin >= maxState) {
                     burnin = maxState / 10;
                     System.out.println("WARNING: Burn-in larger than total number of states - using 10%");
@@ -483,10 +483,10 @@ public class TreeWorkingPriorParsers {
 
                 LogFileTraces traces = new LogFileTraces(fileName, file);
                 traces.loadTraces();
-                int maxState = traces.getMaxState();
+                long maxState = traces.getMaxState();
 
                 // leaving the burnin attribute off will result in 10% being used
-                int burnin = xo.getAttribute("burnin", maxState / 10);
+                long burnin = xo.getAttribute("burnin", maxState / 10);
                 if (burnin < 0 || burnin >= maxState) {
                     burnin = maxState / 10;
                     System.out.println("WARNING: Burn-in larger than total number of states - using 10%");
@@ -639,10 +639,10 @@ public class TreeWorkingPriorParsers {
 
                 LogFileTraces traces = new LogFileTraces(fileName, file);
                 traces.loadTraces();
-                int maxState = traces.getMaxState();
+                long maxState = traces.getMaxState();
 
                 // leaving the burnin attribute off will result in 10% being used
-                int burnin = xo.getAttribute("burnin", maxState / 10);
+                long burnin = xo.getAttribute("burnin", maxState / 10);
                 if (burnin < 0 || burnin >= maxState) {
                     burnin = maxState / 10;
                     System.out.println("WARNING: Burn-in larger than total number of states - using 10%");
@@ -762,10 +762,10 @@ public class TreeWorkingPriorParsers {
 
                 LogFileTraces traces = new LogFileTraces(fileName, file);
                 traces.loadTraces();
-                int maxState = traces.getMaxState();
+                long maxState = traces.getMaxState();
 
                 // leaving the burnin attribute off will result in 10% being used
-                int burnin = xo.getAttribute("burnin", maxState / 10);
+                long burnin = xo.getAttribute("burnin", maxState / 10);
                 if (burnin < 0 || burnin >= maxState) {
                     burnin = maxState / 10;
                     System.out.println("WARNING: Burn-in larger than total number of states - using 10%");
@@ -959,10 +959,10 @@ public class TreeWorkingPriorParsers {
 
                 LogFileTraces traces = new LogFileTraces(fileName, file);
                 traces.loadTraces();
-                int maxState = traces.getMaxState();
+                long maxState = traces.getMaxState();
 
                 // leaving the burnin attribute off will result in 10% being used
-                int burnin = xo.getAttribute("burnin", maxState / 10);
+                long burnin = xo.getAttribute("burnin", maxState / 10);
                 if (burnin < 0 || burnin >= maxState) {
                     burnin = maxState / 10;
                     System.out.println("WARNING: Burn-in larger than total number of states - using 10%");

--- a/src/dr/inference/trace/ArrayTraceList.java
+++ b/src/dr/inference/trace/ArrayTraceList.java
@@ -71,7 +71,7 @@ public class ArrayTraceList extends AbstractTraceList {
         return stepSize;
     }
 
-    public int getMaxState() {
+    public long getMaxState() {
         return getStateCount() * getStepSize();
     }
 

--- a/src/dr/inference/trace/CnCsPerSiteAnalysis.java
+++ b/src/dr/inference/trace/CnCsPerSiteAnalysis.java
@@ -345,15 +345,15 @@ public class CnCsPerSiteAnalysis implements Citable {
                 tracesCN.loadTraces();
                 tracesCS.loadTraces();
 
-                int maxStateCN = tracesCN.getMaxState();
-                int maxStateCS = tracesCS.getMaxState();
+                long maxStateCN = tracesCN.getMaxState();
+                long maxStateCS = tracesCS.getMaxState();
 
                 if (maxStateCN != maxStateCS){
                     System.err.println("max states in" + fileNameCN + "and" + fileNameCS + "are not equal");
                 }
 
                 // leaving the burnin attribute off will result in 10% being used
-                int burnin = xo.getAttribute(BURN_IN, maxStateCN / 10);
+                long burnin = xo.getAttribute(BURN_IN, maxStateCN / 10);
                 //TODO: implement custom burn-in
 
                 if (burnin < 0 || burnin >= maxStateCN) {

--- a/src/dr/inference/trace/CnCsToDnDsPerSiteAnalysis.java
+++ b/src/dr/inference/trace/CnCsToDnDsPerSiteAnalysis.java
@@ -607,15 +607,15 @@ public class CnCsToDnDsPerSiteAnalysis implements Citable {
                 tracesCN.loadTraces();
                 tracesCS.loadTraces();
 
-                int maxStateCN = tracesCN.getMaxState();
-                int maxStateCS = tracesCS.getMaxState();
+                long maxStateCN = tracesCN.getMaxState();
+                long maxStateCS = tracesCS.getMaxState();
 
                 if (maxStateCN != maxStateCS) {
                     System.err.println("max states in" + fileNameCN + " and " + fileNameCS + " are not equal");
                 }
 
                 // leaving the burnin attribute off will result in 10% being used
-                int burnin = xo.getAttribute(BURN_IN, maxStateCN / 10);
+                long burnin = xo.getAttribute(BURN_IN, maxStateCN / 10);
                 //TODO: implement custom burn-in
 
                 if (burnin < 0 || burnin >= maxStateCN) {

--- a/src/dr/inference/trace/DnDsPerSiteAnalysis.java
+++ b/src/dr/inference/trace/DnDsPerSiteAnalysis.java
@@ -485,10 +485,10 @@ public class DnDsPerSiteAnalysis implements Citable {
 
                 LogFileTraces traces = new LogFileTraces(fileName, file);
                 traces.loadTraces();
-                int maxState = traces.getMaxState();
+                long maxState = traces.getMaxState();
 
                 // leaving the burnin attribute off will result in 10% being used
-                int burnin = xo.getAttribute(BURN_IN, maxState / 10);
+                long burnin = xo.getAttribute(BURN_IN, maxState / 10);
                 //TODO: implement custom burn-in
 
                 if (burnin < 0 || burnin >= maxState) {

--- a/src/dr/inference/trace/LogFileTraces.java
+++ b/src/dr/inference/trace/LogFileTraces.java
@@ -59,7 +59,7 @@ public class LogFileTraces extends AbstractTraceList {
     /**
      * @return the last state in the chain
      */
-    public int getMaxState() {
+    public long getMaxState() {
         return lastState;
     }
 
@@ -73,7 +73,7 @@ public class LogFileTraces extends AbstractTraceList {
     public int getStateCount() {
         // This is done as two integer divisions to ensure the same rounding for
         // the burnin...
-        return ((lastState - firstState) / stepSize) - (getBurnIn() / stepSize) + 1;
+        return (int) (((lastState - firstState) / stepSize) - (getBurnIn() / stepSize) + 1);
     }
 
     /**
@@ -129,8 +129,8 @@ public class LogFileTraces extends AbstractTraceList {
         return traces.get(index);
     }
 
-    public void setBurnIn(int burnIn) {
-        this.burnIn = burnIn;
+    public void setBurnIn(long burnin2) {
+        this.burnIn = (int) burnin2;
         for (Trace trace : traces) {
             trace.setTraceStatistics(null);
         }
@@ -236,7 +236,7 @@ public class LogFileTraces extends AbstractTraceList {
         while (tokens != null && tokens.hasMoreTokens()) {
 
             String stateString = tokens.nextToken();
-            int state = 0;
+            long state = 0;
 
             try {
                 try {
@@ -432,13 +432,13 @@ public class LogFileTraces extends AbstractTraceList {
      * @param stateNumber the state
      * @return false if the state number is inconsistent
      */
-    private boolean addState(int stateNumber) {
+    private boolean addState(long stateNumber) {
         if (firstState < 0) {
             firstState = stateNumber;
         } else if (stepSize < 0) {
-            stepSize = stateNumber - firstState;
+            stepSize = (int) (stateNumber - firstState);
         } else {
-            int step = stateNumber - lastState;
+            int step = (int) (stateNumber - lastState);
             if (step != stepSize) {
                 return false;
             }
@@ -463,8 +463,8 @@ public class LogFileTraces extends AbstractTraceList {
     private TreeMap<String, TraceFactory.TraceType> tracesType = new TreeMap<String, TraceFactory.TraceType>();
 
     private int burnIn = -1;
-    private int firstState = -1;
-    private int lastState = -1;
+    private long firstState = -1;
+    private long lastState = -1;
     private int stepSize = -1;
 
     public static class TrimLineReader extends BufferedReader {

--- a/src/dr/inference/trace/LogFileTraces.java
+++ b/src/dr/inference/trace/LogFileTraces.java
@@ -241,7 +241,7 @@ public class LogFileTraces extends AbstractTraceList {
             try {
                 try {
                     // Changed this to parseDouble because LAMARC uses scientific notation for the state number
-                    state = (int) Double.parseDouble(stateString);
+                    state = (long) Double.parseDouble(stateString);
                 } catch (NumberFormatException nfe) {
                     throw new TraceException("Unable to parse state number in column 1 (Line " + reader.getLineNumber() + ")");
                 }
@@ -440,6 +440,8 @@ public class LogFileTraces extends AbstractTraceList {
         } else {
             int step = (int) (stateNumber - lastState);
             if (step != stepSize) {
+            	//System.out.println("stateNumber: " + stateNumber + " lastState: " + lastState);
+            	//System.out.println("step: " + step + " != " + stepSize);
                 return false;
             }
         }

--- a/src/dr/inference/trace/OldDnDsPerSiteAnalysis.java
+++ b/src/dr/inference/trace/OldDnDsPerSiteAnalysis.java
@@ -343,10 +343,10 @@ public class OldDnDsPerSiteAnalysis {
 
                 LogFileTraces traces = new LogFileTraces(fileName, file);
                 traces.loadTraces();
-                int maxState = traces.getMaxState();
+                long maxState = traces.getMaxState();
 
                 // leaving the burnin attribute off will result in 10% being used
-                int burnin = xo.getAttribute(MarginalLikelihoodAnalysisParser.BURN_IN, maxState / 10);
+                long burnin = xo.getAttribute(MarginalLikelihoodAnalysisParser.BURN_IN, maxState / 10);
                 //TODO: implement custom burn-in
 
                 if (burnin < 0 || burnin >= maxState) {

--- a/src/dr/inference/trace/PathSamplingAnalysis.java
+++ b/src/dr/inference/trace/PathSamplingAnalysis.java
@@ -152,10 +152,10 @@ public class PathSamplingAnalysis {
                     
                     LogFileTraces traces = new LogFileTraces(fileName, file);
                     traces.loadTraces();
-                    int maxState = traces.getMaxState();
+                    long maxState = traces.getMaxState();
                     
                     // leaving the burnin attribute off will result in 10% being used
-                    int burnin = xo.getAttribute(MarginalLikelihoodAnalysisParser.BURN_IN, maxState / 5);
+                    long burnin = xo.getAttribute(MarginalLikelihoodAnalysisParser.BURN_IN, maxState / 5);
 
                     if (burnin < 0 || burnin >= maxState) {
                         burnin = maxState / 5;

--- a/src/dr/inference/trace/TraceAnalysis.java
+++ b/src/dr/inference/trace/TraceAnalysis.java
@@ -85,7 +85,7 @@ public class TraceAnalysis {
 
         int burnin = inBurnin;
         if (burnin == -1) {
-            burnin = traces.getMaxState() / 10;
+            burnin = (int) (traces.getMaxState() / 10);
         }
 
         traces.setBurnIn(burnin);
@@ -183,7 +183,7 @@ public class TraceAnalysis {
         traces.loadTraces();
         int burnin = inBurnin;
         if (burnin == -1) {
-            burnin = traces.getMaxState() / 10;
+            burnin = (int) (traces.getMaxState() / 10);
         }
 
         traces.setBurnIn(burnin);
@@ -244,7 +244,7 @@ public class TraceAnalysis {
 
         TraceList traces = analyzeLogFile(filename, burnin);
 
-        int maxState = traces.getMaxState();
+        long maxState = traces.getMaxState();
 
         double minESS = Double.MAX_VALUE;
 

--- a/src/dr/inference/trace/TraceList.java
+++ b/src/dr/inference/trace/TraceList.java
@@ -82,7 +82,7 @@ public interface TraceList {
     /**
      * @return the last state in the chain
      */
-    int getMaxState();
+    long getMaxState();
 
     boolean isIncomplete();
 

--- a/src/dr/inferencexml/distribution/WorkingPriorParsers.java
+++ b/src/dr/inferencexml/distribution/WorkingPriorParsers.java
@@ -81,10 +81,10 @@ public class WorkingPriorParsers {
 
                 LogFileTraces traces = new LogFileTraces(fileName, file);
                 traces.loadTraces();
-                int maxState = traces.getMaxState();
+                long maxState = traces.getMaxState();
 
                 // leaving the burnin attribute off will result in 10% being used
-                int burnin = xo.getAttribute("burnin", maxState / 10);
+                long burnin = xo.getAttribute("burnin", maxState / 10);
                 if (burnin < 0 || burnin >= maxState) {
                     burnin = maxState / 10;
                     System.out.println("WARNING: Burn-in larger than total number of states - using 10%");
@@ -173,10 +173,10 @@ public class WorkingPriorParsers {
 
                 LogFileTraces traces = new LogFileTraces(fileName, file);
                 traces.loadTraces();
-                int maxState = traces.getMaxState();
+                long maxState = traces.getMaxState();
 
                 // leaving the burnin attribute off will result in 10% being used
-                int burnin = xo.getAttribute("burnin", maxState / 10);
+                long burnin = xo.getAttribute("burnin", maxState / 10);
                 if (burnin < 0 || burnin >= maxState) {
                     burnin = maxState / 10;
                     System.out.println("WARNING: Burn-in larger than total number of states - using 10%");
@@ -268,10 +268,10 @@ public class WorkingPriorParsers {
 
                 LogFileTraces traces = new LogFileTraces(fileName, file);
                 traces.loadTraces();
-                int maxState = traces.getMaxState();
+                long maxState = traces.getMaxState();
 
                 // leaving the burnin attribute off will result in 10% being used
-                int burnin = xo.getAttribute("burnin", maxState / 10);
+                long burnin = xo.getAttribute("burnin", maxState / 10);
                 if (burnin < 0 || burnin >= maxState) {
                     burnin = maxState / 10;
                     System.out.println("WARNING: Burn-in larger than total number of states - using 10%");
@@ -363,10 +363,10 @@ public class WorkingPriorParsers {
 
                 LogFileTraces traces = new LogFileTraces(fileName, file);
                 traces.loadTraces();
-                int maxState = traces.getMaxState();
+                long maxState = traces.getMaxState();
 
                 // leaving the burnin attribute off will result in 10% being used
-                int burnin = xo.getAttribute("burnin", maxState / 10);
+                long burnin = xo.getAttribute("burnin", maxState / 10);
                 if (burnin < 0 || burnin >= maxState) {
                     burnin = maxState / 10;
                     System.out.println("WARNING: Burn-in larger than total number of states - using 10%");

--- a/src/dr/inferencexml/trace/AICMAnalysisParser.java
+++ b/src/dr/inferencexml/trace/AICMAnalysisParser.java
@@ -49,9 +49,9 @@ public class AICMAnalysisParser extends AbstractXMLObjectParser {
             // Load traces and remove burnin
             LogFileTraces traces = new LogFileTraces(fileName, file);
             traces.loadTraces();
-            int maxState = traces.getMaxState();
+            long maxState = traces.getMaxState();
 
-            int burnin = xo.getAttribute(BURN_IN, maxState / 10);
+            long burnin = xo.getAttribute(BURN_IN, maxState / 10);
 
             if (burnin < 0 || burnin >= maxState) {
                 burnin = maxState / 10;
@@ -81,7 +81,7 @@ public class AICMAnalysisParser extends AbstractXMLObjectParser {
             List<Double> sample = traces.getValues(traceIndex);
 
             MarginalLikelihoodAnalysis analysis = new MarginalLikelihoodAnalysis(sample,
-                    traces.getTraceName(traceIndex), burnin, analysisType, bootstrapLength);
+                    traces.getTraceName(traceIndex), (int)burnin, analysisType, bootstrapLength);
 
             System.out.println(analysis.toString());
 

--- a/src/dr/inferencexml/trace/ArithmeticMeanAnalysisParser.java
+++ b/src/dr/inferencexml/trace/ArithmeticMeanAnalysisParser.java
@@ -57,9 +57,9 @@ public class ArithmeticMeanAnalysisParser extends AbstractXMLObjectParser {
             // Load traces and remove burnin
             LogFileTraces traces = new LogFileTraces(fileName, file);
             traces.loadTraces();
-            int maxState = traces.getMaxState();
+            long maxState = traces.getMaxState();
 
-            int burnin = xo.getAttribute(BURN_IN, maxState / 10);
+            long burnin = xo.getAttribute(BURN_IN, maxState / 10);
 
             if (burnin < 0 || burnin >= maxState) {
                 burnin = maxState / 10;
@@ -89,7 +89,7 @@ public class ArithmeticMeanAnalysisParser extends AbstractXMLObjectParser {
             List<Double> sample = traces.getValues(traceIndex);
 
             MarginalLikelihoodAnalysis analysis = new MarginalLikelihoodAnalysis(sample,
-                    traces.getTraceName(traceIndex), burnin, analysisType, bootstrapLength);
+                    traces.getTraceName(traceIndex), (int)burnin, analysisType, bootstrapLength);
 
             System.out.println(analysis.toString());
 

--- a/src/dr/inferencexml/trace/HarmonicMeanAnalysisParser.java
+++ b/src/dr/inferencexml/trace/HarmonicMeanAnalysisParser.java
@@ -55,12 +55,12 @@ public class HarmonicMeanAnalysisParser extends AbstractXMLObjectParser {
             // Load traces and remove burnin
             LogFileTraces traces = new LogFileTraces(fileName, file);
             traces.loadTraces();
-            int maxState = traces.getMaxState();
+            long maxState = traces.getMaxState();
 
-            int burnin = xo.getAttribute(BURN_IN, maxState / 10);
+            long burnin = xo.getAttribute(BURN_IN, maxState / 10);
 
             if (burnin < 0 || burnin >= maxState) {
-                burnin = maxState / 10;
+                burnin = (int) (maxState / 10);
                 System.out.println("WARNING: Burn-in larger than total number of states - using to 10%");
             }
 
@@ -87,7 +87,7 @@ public class HarmonicMeanAnalysisParser extends AbstractXMLObjectParser {
             List<Double> sample = traces.getValues(traceIndex);
 
             MarginalLikelihoodAnalysis analysis = new MarginalLikelihoodAnalysis(sample,
-                    traces.getTraceName(traceIndex), burnin, analysisType, bootstrapLength);
+                    traces.getTraceName(traceIndex), (int)burnin, analysisType, bootstrapLength);
 
             System.out.println(analysis.toString());
 

--- a/src/dr/inferencexml/trace/MarginalLikelihoodAnalysisParser.java
+++ b/src/dr/inferencexml/trace/MarginalLikelihoodAnalysisParser.java
@@ -49,10 +49,10 @@ public class MarginalLikelihoodAnalysisParser extends AbstractXMLObjectParser {
 
             LogFileTraces traces = new LogFileTraces(fileName, file);
             traces.loadTraces();
-            int maxState = traces.getMaxState();
+            long maxState = traces.getMaxState();
 
             // leaving the burnin attribute off will result in 10% being used
-            int burnin = xo.getAttribute(BURN_IN, maxState / 10);
+            long burnin = xo.getAttribute(BURN_IN, maxState / 10);
 
             if (burnin < 0 || burnin >= maxState) {
                 burnin = maxState / 10;
@@ -88,7 +88,7 @@ public class MarginalLikelihoodAnalysisParser extends AbstractXMLObjectParser {
             List<Double> sample = traces.getValues(traceIndex);
 
             MarginalLikelihoodAnalysis analysis = new MarginalLikelihoodAnalysis(sample,
-                    traces.getTraceName(traceIndex), burnin, analysisType, bootstrapLength);
+                    traces.getTraceName(traceIndex), (int)burnin, analysisType, bootstrapLength);
 
             System.out.println(analysis.toString());
 


### PR DESCRIPTION
Addresses an issue where if the states ended up larger that 2^31 then tracer would generate an error about non-consistent spaces between states.

This occurs when you have one state below 2^31 and the next state above 2^31
This would generate an exception with a very poor description for the user to decipher about 
``State X is not consistent with previous spacing (Line N)``