### PR TITLE
Remove outdated build step

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -469,9 +469,6 @@
         <copy file="${dist}/beauti.jar" todir="${Linux_package_dir}/lib"/>
         <copy file="${dist}/beast.jar" todir="${Linux_package_dir}/lib"/>
         <!-- <copy file="${dist}/beast-beagle.jar" todir="${Linux_package_dir}/lib"/> -->
-        <copy todir="${Linux_package_dir}/lib">
-            <fileset dir="${Linux_dir}/lib"/>
-        </copy>
         <copy file="${common_dir}/VERSION HISTORY.txt" todir="${Linux_package_dir}"/>
         <copy file="${common_dir}/README.txt" todir="${Linux_package_dir}"/>
 


### PR DESCRIPTION
8fe3ad33e91930fdc85a0d1a130ef02e9f629005 removed these precompiled likelihood cores, but didn't remove the step that installed them in `build.xml`. When packaging BEAST v1.10.1 for Homebrew https://github.com/Homebrew/homebrew-core/pull/31000 I could not build BEAST with `ant linux`. 

```
Buildfile: /private/tmp/beast-20180810-66017-ct4k7w/beast-mcmc-1.10.1/build.xml

init:
     [echo] BEAST: /private/tmp/beast-20180810-66017-ct4k7w/beast-mcmc-1.10.1/build.xml

compile-all:
    [javac] /private/tmp/beast-20180810-66017-ct4k7w/beast-mcmc-1.10.1/build.xml:76: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds
    [javac] Compiling 3 source files to /private/tmp/beast-20180810-66017-ct4k7w/beast-mcmc-1.10.1/build
    [javac] warning: [options] bootstrap class path not set in conjunction with -source 1.6
    [javac] 1 warning
     [echo] Successfully compiled.

dist:

linux:
   [delete] Deleting directory /private/tmp/beast-20180810-66017-ct4k7w/beast-mcmc-1.10.1/release/Linux/BEASTv1.10.1
    [mkdir] Created dir: /private/tmp/beast-20180810-66017-ct4k7w/beast-mcmc-1.10.1/release/Linux/BEASTv1.10.1
     [copy] Copying 6 files to /private/tmp/beast-20180810-66017-ct4k7w/beast-mcmc-1.10.1/release/Linux/BEASTv1.10.1/bin
     [copy] Copying 5 files to /private/tmp/beast-20180810-66017-ct4k7w/beast-mcmc-1.10.1/release/Linux/BEASTv1.10.1/doc
     [copy] Copying 158 files to /private/tmp/beast-20180810-66017-ct4k7w/beast-mcmc-1.10.1/release/Linux/BEASTv1.10.1/examples
     [copy] Copying 18 files to /private/tmp/beast-20180810-66017-ct4k7w/beast-mcmc-1.10.1/release/Linux/BEASTv1.10.1/native
     [copy] Copying 1 file to /private/tmp/beast-20180810-66017-ct4k7w/beast-mcmc-1.10.1/release/Linux/BEASTv1.10.1/images
     [copy] Copying 1 file to /private/tmp/beast-20180810-66017-ct4k7w/beast-mcmc-1.10.1/release/Linux/BEASTv1.10.1/images
     [copy] Copying 1 file to /private/tmp/beast-20180810-66017-ct4k7w/beast-mcmc-1.10.1/release/Linux/BEASTv1.10.1/images
     [copy] Copying 1 file to /private/tmp/beast-20180810-66017-ct4k7w/beast-mcmc-1.10.1/release/Linux/BEASTv1.10.1/lib
     [copy] Copying 1 file to /private/tmp/beast-20180810-66017-ct4k7w/beast-mcmc-1.10.1/release/Linux/BEASTv1.10.1/lib

BUILD FAILED
/private/tmp/beast-20180810-66017-ct4k7w/beast-mcmc-1.10.1/build.xml:472: /private/tmp/beast-20180810-66017-ct4k7w/beast-mcmc-1.10.1/release/Linux/lib does not exist.
```

Removing these lines fixes the error and allows BEAST to build.