### PR TITLE
fixing junit tests

### DIFF
--- a/src/dr/inference/model/CompoundLikelihood.java
+++ b/src/dr/inference/model/CompoundLikelihood.java
@@ -333,19 +333,7 @@ public class CompoundLikelihood implements Likelihood, Profileable, Reportable, 
         return message;
     }
 
-    public void getDensities(Map<String, Double> densities) {
 
-        for( Likelihood lik : likelihoods ) {
-
-            if( lik instanceof CompoundLikelihood ) {
-                ((CompoundLikelihood) lik).getDensities(densities);
-            } else {
-
-                final double logLikelihood = lik.getLogLikelihood();
-                densities.put(lik.prettyName(), logLikelihood);
-            }
-        }
-    }
 
     public String toString() {
         return getId();


### PR DESCRIPTION
Doesn't require likelihoods in MarkovChain to be able to be cast to `CompoundLikelihood`. I'm not sure how often this situation arises in practice, but it was disrupting the unit tests.