### PR TITLE
Option for returning non-zero exit code on uncaught exception in thread

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 for file in TestXML/*\.xml
 do
-  if java -Djava.library.path=${BEAGLE_LIB} -jar ../build/dist/beast.jar -seed 666 -overwrite $file; then
+  if java -Djava.library.path=${BEAGLE_LIB} -jar ../build/dist/beast.jar -fail_threads -seed 666 -overwrite $file; then
     echo $file passed
   else
     echo $file failed; exit -1

--- a/ci/test_with_load_state.sh
+++ b/ci/test_with_load_state.sh
@@ -2,7 +2,7 @@
 for file in TestXMLwithLoadState/*\.xml
 do
   filename=$(basename $file .xml)
-  if java -Djava.library.path=${BEAGLE_LIB} -jar ../build/dist/beast.jar -seed 666 -load_state $filename.chkpt -overwrite $file; then
+  if java -Djava.library.path=${BEAGLE_LIB} -jar ../build/dist/beast.jar -fail_threads -seed 666 -load_state $filename.chkpt -overwrite $file; then
     echo $file passed
   else
     echo $file failed; exit -1

--- a/src/dr/app/beast/BeastMain.java
+++ b/src/dr/app/beast/BeastMain.java
@@ -336,7 +336,7 @@ public class BeastMain {
                         new Arguments.Option("overwrite", "Allow overwriting of log files"),
                         new Arguments.IntegerOption("errors", "Specify maximum number of numerical errors before stopping"),
                         new Arguments.IntegerOption("threads", "The number of computational threads to use (default auto)"),
-                        new Arguments.Option("fail_threads", "Exit with error on uncaught exceptio in thread."),
+                        new Arguments.Option("fail_threads", "Exit with error on uncaught exception in thread."),
                         new Arguments.Option("java", "Use Java only, no native implementations"),
                         new Arguments.LongOption("tests", "The number of full evaluation tests to perform (default 1000)"),
                         new Arguments.RealOption("threshold", 0.0, Double.MAX_VALUE, "Full evaluation test threshold (default 0.1)"),
@@ -619,7 +619,7 @@ public class BeastMain {
                 public void uncaughtException(Thread t, Throwable e) {
                     System.err.println("Error in thread " + t.getName() + ": ");
                     e.printStackTrace();
-                    System.exit(1);
+                    System.exit(-1);
                 }
             };
 

--- a/src/dr/app/beast/BeastMain.java
+++ b/src/dr/app/beast/BeastMain.java
@@ -336,6 +336,7 @@ public class BeastMain {
                         new Arguments.Option("overwrite", "Allow overwriting of log files"),
                         new Arguments.IntegerOption("errors", "Specify maximum number of numerical errors before stopping"),
                         new Arguments.IntegerOption("threads", "The number of computational threads to use (default auto)"),
+                        new Arguments.Option("fail_threads", "Exit with error on uncaught exceptio in thread."),
                         new Arguments.Option("java", "Use Java only, no native implementations"),
                         new Arguments.LongOption("tests", "The number of full evaluation tests to perform (default 1000)"),
                         new Arguments.RealOption("threshold", 0.0, Double.MAX_VALUE, "Full evaluation test threshold (default 0.1)"),
@@ -609,6 +610,20 @@ public class BeastMain {
                 System.err.println("The the number of threads should be >= 0");
                 System.exit(1);
             }
+        }
+
+        if (arguments.hasOption("fail_threads")) {
+
+            Thread.UncaughtExceptionHandler handler = new Thread.UncaughtExceptionHandler() {
+                @Override
+                public void uncaughtException(Thread t, Throwable e) {
+                    System.err.println("Error in thread " + t.getName() + ": ");
+                    e.printStackTrace();
+                    System.exit(1);
+                }
+            };
+
+            Thread.setDefaultUncaughtExceptionHandler(handler);
         }
 
         if (arguments.hasOption("seed")) {


### PR DESCRIPTION
At the moment, there's a lot of machinery in `BeastMain` for handling exceptions in the __main__ thread, but these don't apply to exceptions that occur in other threads, which is where almost all of the non-xml related exceptions will occur. This isn't ideal for the continuous integration framework, since Travis can't distinguish between a passed test or an uncaught exception in a thread.

That being said, uncaught exceptions in threads shouldn't automatically call `System.exit(<code>)` because that would cause the GUI window to automatically close on uncaught exceptions.

Including it as a simple program argument `-fail_threads` and using this argument in the continuous integration seems the simplest way to get the best of both worlds. Perhaps a more elegant solution would be to setup a `ThreadPoolExecutor` (see https://stackoverflow.com/questions/2248131/handling-exceptions-from-java-executorservice-tasks?rq=1), but this seems like overkill at the moment and would require bigger changes.