### PR TITLE
moving conditionalProbabilities to log space in AncestralStateBeagleT…

### DIFF
--- a/src/dr/evomodel/treelikelihood/AncestralStateBeagleTreeLikelihood.java
+++ b/src/dr/evomodel/treelikelihood/AncestralStateBeagleTreeLikelihood.java
@@ -25,7 +25,6 @@
 
 package dr.evomodel.treelikelihood;
 
-import dr.evolution.datatype.HiddenCodons;
 import dr.evomodel.branchmodel.BranchModel;
 import dr.evomodel.siteratemodel.SiteRateModel;
 import dr.evolution.alignment.PatternList;
@@ -53,7 +52,7 @@ import java.util.Set;
  */
 
 public class AncestralStateBeagleTreeLikelihood extends BeagleTreeLikelihood implements TreeTraitProvider, AncestralStateTraitProvider {
-
+    private static final boolean CONDITIONAL_PROBABILITIES_IN_LOG_SPACE = true;
 //    public AncestralStateBeagleTreeLikelihood(PatternList patternList, TreeModel treeModel,
 //                                              BranchSubstitutionModel branchSubstitutionModel, SiteRateModel siteRateModel,
 //                                              BranchRateModel branchRateModel, boolean useAmbiguities,
@@ -235,9 +234,13 @@ public class AncestralStateBeagleTreeLikelihood extends BeagleTreeLikelihood imp
             }
             return choice;
         } else {
+            if(CONDITIONAL_PROBABILITIES_IN_LOG_SPACE){
+                return MathUtils.randomChoiceLogPDF(measure);
+            }
             return MathUtils.randomChoicePDF(measure);
         }
     }
+
 
     public void makeDirty() {
         super.makeDirty();
@@ -423,13 +426,19 @@ public class AncestralStateBeagleTreeLikelihood extends BeagleTreeLikelihood imp
                     }
 
                     // Sample root character state
-                    int partialsIndex = (rateCategory == null ? 0 : rateCategory[j]) * stateCount * patternCount;
-                    System.arraycopy(partials, partialsIndex + j * stateCount, conditionalProbabilities, 0, stateCount);
+                    int partialsIndex = (rateCategory == null ? 0 : rateCategory[j]) * stateCount * patternCount + j * stateCount;
+
 
                     double[] frequencies = substitutionModelDelegate.getRootStateFrequencies(); // TODO May have more than one set of frequencies
+
                     for (int i = 0; i < stateCount; i++) {
-                        conditionalProbabilities[i] *= frequencies[i];
+                         if (CONDITIONAL_PROBABILITIES_IN_LOG_SPACE) {
+                             conditionalProbabilities[i] = Math.log(partials[partialsIndex + i]) + Math.log(frequencies[i]);
+                         } else {
+                             conditionalProbabilities[i] = partials[partialsIndex + i] * frequencies[i];
+                         }
                     }
+
                     try {
                         state[j] = drawChoice(conditionalProbabilities);
                     } catch (Error e) {
@@ -472,9 +481,16 @@ public class AncestralStateBeagleTreeLikelihood extends BeagleTreeLikelihood imp
                     int matrixIndex = category * stateCount * stateCount;
                     int partialIndex = category * stateCount * patternCount;
 
-                    for (int i = 0; i < stateCount; i++)
-                        conditionalProbabilities[i] = partialLikelihood[partialIndex + childIndex + i]
-                                * probabilities[matrixIndex + parentIndex + i];
+                    for (int i = 0; i < stateCount; i++) {
+                        if (CONDITIONAL_PROBABILITIES_IN_LOG_SPACE) {
+                            conditionalProbabilities[i] = Math.log(partialLikelihood[partialIndex + childIndex + i])
+                                    + Math.log(probabilities[matrixIndex + parentIndex + i]);
+                        } else {
+                            conditionalProbabilities[i] = partialLikelihood[partialIndex + childIndex + i]
+                                    * probabilities[matrixIndex + parentIndex + i];
+                        }
+
+                    }
 
                     state[j] = drawChoice(conditionalProbabilities);
                     reconstructedStates[nodeNum][j] = state[j];
@@ -508,9 +524,13 @@ public class AncestralStateBeagleTreeLikelihood extends BeagleTreeLikelihood imp
                     int category = rateCategory == null ? 0 : rateCategory[j];
                     int matrixIndex = category * stateCount * stateCount;
 
-                    System.arraycopy(probabilities, parentIndex + matrixIndex, conditionalProbabilities, 0, stateCount);
-                    for (int k = 0; k < stateCount; ++k) {
-                        conditionalProbabilities[k] *= partials[j * stateCount + k];
+                    int probabilityIndex = parentIndex + matrixIndex;
+                    for (int k = 0; k < stateCount; k++) {
+                        if(CONDITIONAL_PROBABILITIES_IN_LOG_SPACE){
+                            conditionalProbabilities[k] = Math.log(probabilities[probabilityIndex + k])+ Math.log(partials[j * stateCount + k]);
+                        }else{
+                            conditionalProbabilities[k] = probabilities[probabilityIndex + k]* partials[j * stateCount + k];
+                        }
                     }
                     reconstructedStates[nodeNum][j] = drawChoice(conditionalProbabilities);
 
@@ -548,6 +568,12 @@ public class AncestralStateBeagleTreeLikelihood extends BeagleTreeLikelihood imp
                                 }
                             }
                         }
+
+                        if (CONDITIONAL_PROBABILITIES_IN_LOG_SPACE) {
+                            for (int k = 0; k < stateCount; k++) {
+                                conditionalProbabilities[k] = Math.log(conditionalProbabilities[k]);
+                            }
+                        }
                         reconstructedStates[nodeNum][j] = drawChoice(conditionalProbabilities);
                     }
 
@@ -561,7 +587,6 @@ public class AncestralStateBeagleTreeLikelihood extends BeagleTreeLikelihood imp
                     }
                 }
             }
-
             hookCalculation(tree, parent, node, parentState, reconstructedStates[nodeNum], null, rateCategory);
         }
     }

--- a/src/dr/evomodel/treelikelihood/AncestralStateBeagleTreeLikelihood.java
+++ b/src/dr/evomodel/treelikelihood/AncestralStateBeagleTreeLikelihood.java
@@ -52,7 +52,6 @@ import java.util.Set;
  */
 
 public class AncestralStateBeagleTreeLikelihood extends BeagleTreeLikelihood implements TreeTraitProvider, AncestralStateTraitProvider {
-    private static final boolean CONDITIONAL_PROBABILITIES_IN_LOG_SPACE = true;
 //    public AncestralStateBeagleTreeLikelihood(PatternList patternList, TreeModel treeModel,
 //                                              BranchSubstitutionModel branchSubstitutionModel, SiteRateModel siteRateModel,
 //                                              BranchRateModel branchRateModel, boolean useAmbiguities,
@@ -77,11 +76,12 @@ public class AncestralStateBeagleTreeLikelihood extends BeagleTreeLikelihood imp
                                               final String tag,
 //                                              SubstitutionModel substModel,
                                               boolean useMAP,
-                                              boolean returnML) {
+                                              boolean returnML,
+                                              boolean conditionalProbabilitiesInLogSpace) {
 
         super(patternList, treeModel, branchModel, siteRateModel, branchRateModel, tipStatesModel, useAmbiguities, scalingScheme, delayRescalingUntilUnderflow,
                 partialsRestrictions);
-
+        this.conditionalProbabilitiesInLogSpace = conditionalProbabilitiesInLogSpace;
         this.dataType = dataType;
 //        this.tag = tag;
 
@@ -139,6 +139,24 @@ public class AncestralStateBeagleTreeLikelihood extends BeagleTreeLikelihood imp
         });
 
     }
+    public AncestralStateBeagleTreeLikelihood(PatternList patternList, TreeModel treeModel,
+                                              BranchModel branchModel,
+                                              SiteRateModel siteRateModel,
+                                              BranchRateModel branchRateModel,
+                                              TipStatesModel tipStatesModel,
+                                              boolean useAmbiguities,
+                                              PartialsRescalingScheme scalingScheme,
+                                              boolean delayRescalingUntilUnderflow,
+                                              Map<Set<String>, Parameter> partialsRestrictions,
+                                              final DataType dataType,
+                                              final String tag,
+//                                              SubstitutionModel substModel,
+                                              boolean useMAP,
+                                              boolean returnML){
+        this(patternList, treeModel, branchModel, siteRateModel, branchRateModel, tipStatesModel, useAmbiguities,
+                scalingScheme, delayRescalingUntilUnderflow, partialsRestrictions, dataType, tag, useMAP, returnML, false);
+    }
+
 
     private double[] getPartials(PatternList patternList, int sequenceIndex) {
         double[] partials = new double[patternCount * stateCount];
@@ -234,7 +252,7 @@ public class AncestralStateBeagleTreeLikelihood extends BeagleTreeLikelihood imp
             }
             return choice;
         } else {
-            if(CONDITIONAL_PROBABILITIES_IN_LOG_SPACE){
+            if(conditionalProbabilitiesInLogSpace){
                 return MathUtils.randomChoiceLogPDF(measure);
             }
             return MathUtils.randomChoicePDF(measure);
@@ -432,7 +450,7 @@ public class AncestralStateBeagleTreeLikelihood extends BeagleTreeLikelihood imp
                     double[] frequencies = substitutionModelDelegate.getRootStateFrequencies(); // TODO May have more than one set of frequencies
 
                     for (int i = 0; i < stateCount; i++) {
-                         if (CONDITIONAL_PROBABILITIES_IN_LOG_SPACE) {
+                         if (conditionalProbabilitiesInLogSpace) {
                              conditionalProbabilities[i] = Math.log(partials[partialsIndex + i]) + Math.log(frequencies[i]);
                          } else {
                              conditionalProbabilities[i] = partials[partialsIndex + i] * frequencies[i];
@@ -482,7 +500,7 @@ public class AncestralStateBeagleTreeLikelihood extends BeagleTreeLikelihood imp
                     int partialIndex = category * stateCount * patternCount;
 
                     for (int i = 0; i < stateCount; i++) {
-                        if (CONDITIONAL_PROBABILITIES_IN_LOG_SPACE) {
+                        if (conditionalProbabilitiesInLogSpace) {
                             conditionalProbabilities[i] = Math.log(partialLikelihood[partialIndex + childIndex + i])
                                     + Math.log(probabilities[matrixIndex + parentIndex + i]);
                         } else {
@@ -526,7 +544,7 @@ public class AncestralStateBeagleTreeLikelihood extends BeagleTreeLikelihood imp
 
                     int probabilityIndex = parentIndex + matrixIndex;
                     for (int k = 0; k < stateCount; k++) {
-                        if(CONDITIONAL_PROBABILITIES_IN_LOG_SPACE){
+                        if(conditionalProbabilitiesInLogSpace){
                             conditionalProbabilities[k] = Math.log(probabilities[probabilityIndex + k])+ Math.log(partials[j * stateCount + k]);
                         }else{
                             conditionalProbabilities[k] = probabilities[probabilityIndex + k]* partials[j * stateCount + k];
@@ -569,7 +587,7 @@ public class AncestralStateBeagleTreeLikelihood extends BeagleTreeLikelihood imp
                             }
                         }
 
-                        if (CONDITIONAL_PROBABILITIES_IN_LOG_SPACE) {
+                        if (conditionalProbabilitiesInLogSpace) {
                             for (int k = 0; k < stateCount; k++) {
                                 conditionalProbabilities[k] = Math.log(conditionalProbabilities[k]);
                             }
@@ -618,6 +636,7 @@ public class AncestralStateBeagleTreeLikelihood extends BeagleTreeLikelihood imp
     private double[] partials;
 
     protected int[] rateCategory = null;
+    private final boolean conditionalProbabilitiesInLogSpace;
 //    private double[] rootPartials;
 //    private int[][] cumulativeScaleBuffers;
 //    private int scaleBufferIndex;

--- a/src/dr/evomodel/treelikelihood/MarkovJumpsBeagleTreeLikelihood.java
+++ b/src/dr/evomodel/treelikelihood/MarkovJumpsBeagleTreeLikelihood.java
@@ -76,10 +76,12 @@ public class MarkovJumpsBeagleTreeLikelihood extends AncestralStateBeagleTreeLik
                                            boolean returnMarginalLikelihood,
                                            boolean useUniformization,
                                            boolean reportUnconditionedColumns,
-                                           int nSimulants) {
+                                           int nSimulants,
+                                           boolean conditionalProbabilitiesInLogSpace) {
 
         super(patternList, treeModel, branchModel, siteRateModel, branchRateModel, tipStatesModel, useAmbiguities,
-                scalingScheme, delayScaling, partialsRestrictions, dataType, stateTag, useMAP, returnMarginalLikelihood);
+                scalingScheme, delayScaling, partialsRestrictions, dataType, stateTag, useMAP, returnMarginalLikelihood,
+                conditionalProbabilitiesInLogSpace);
 
         this.useUniformization = useUniformization;
         this.reportUnconditionedColumns = reportUnconditionedColumns;
@@ -96,6 +98,26 @@ public class MarkovJumpsBeagleTreeLikelihood extends AncestralStateBeagleTreeLik
         condJumps = new double[categoryCount][stateCount * stateCount];
     }
 
+    public MarkovJumpsBeagleTreeLikelihood(PatternList patternList, TreeModel treeModel,
+                                           BranchModel branchModel,
+                                           SiteRateModel siteRateModel,
+                                           BranchRateModel branchRateModel,
+                                           TipStatesModel tipStatesModel,
+                                           boolean useAmbiguities,
+                                           PartialsRescalingScheme scalingScheme,
+                                           boolean delayScaling,
+                                           Map<Set<String>, Parameter> partialsRestrictions,
+                                           DataType dataType, String stateTag,
+                                           boolean useMAP,
+                                           boolean returnMarginalLikelihood,
+                                           boolean useUniformization,
+                                           boolean reportUnconditionedColumns,
+                                           int nSimulants){
+        this(patternList,  treeModel,branchModel,siteRateModel,branchRateModel,tipStatesModel,useAmbiguities,
+                scalingScheme, delayScaling,partialsRestrictions,dataType, stateTag, useMAP,returnMarginalLikelihood,
+                useUniformization, reportUnconditionedColumns, nSimulants,false);
+    }
+
     public void addRegister(Parameter addRegisterParameter,
                             MarkovJumpsType type,
                             boolean scaleByTime) {
@@ -104,7 +126,7 @@ public class MarkovJumpsBeagleTreeLikelihood extends AncestralStateBeagleTreeLik
                 addRegisterParameter.getDimension() != stateCount * stateCount) ||
                 (type == MarkovJumpsType.REWARDS &&
                         addRegisterParameter.getDimension() != stateCount)
-                ) {
+        ) {
             throw new RuntimeException("Register parameter of wrong dimension");
         }
         addVariable(addRegisterParameter);

--- a/src/dr/evomodelxml/treelikelihood/AncestralStateTreeLikelihoodParser.java
+++ b/src/dr/evomodelxml/treelikelihood/AncestralStateTreeLikelihoodParser.java
@@ -57,6 +57,7 @@ public class AncestralStateTreeLikelihoodParser extends BeagleTreeLikelihoodPars
     public static final String RECONSTRUCTION_TAG_NAME = "stateTagName";
     public static final String MAP_RECONSTRUCTION = "useMAP";
     public static final String MARGINAL_LIKELIHOOD = "useMarginalLikelihood";
+    public static final String CONDITIONAL_PROBABILITIES_IN_LOG_SPACE = "conditionalProbabilitiesInLogSpace";
 
     public String getParserName() {
         return RECONSTRUCTING_TREE_LIKELIHOOD;
@@ -87,6 +88,7 @@ public class AncestralStateTreeLikelihoodParser extends BeagleTreeLikelihoodPars
 
         boolean useMAP = xo.getAttribute(MAP_RECONSTRUCTION, false);
         boolean useMarginalLogLikelihood = xo.getAttribute(MARGINAL_LIKELIHOOD, true);
+        boolean conditionalProbabilitiesInLogSpace = xo.getAttribute(CONDITIONAL_PROBABILITIES_IN_LOG_SPACE, false);
 
         if (patternList.areUnique()) {
             throw new XMLParseException("Ancestral state reconstruction cannot be used with compressed (unique) patterns.");
@@ -106,7 +108,8 @@ public class AncestralStateTreeLikelihoodParser extends BeagleTreeLikelihoodPars
                 dataType,
                 tag,
                 useMAP,
-                useMarginalLogLikelihood
+                useMarginalLogLikelihood,
+                conditionalProbabilitiesInLogSpace
         );
     }
 

--- a/src/dr/evomodelxml/treelikelihood/MarkovJumpsTreeLikelihoodParser.java
+++ b/src/dr/evomodelxml/treelikelihood/MarkovJumpsTreeLikelihoodParser.java
@@ -89,6 +89,8 @@ public class MarkovJumpsTreeLikelihoodParser extends AncestralStateTreeLikelihoo
 
         boolean useMAP = xo.getAttribute(MAP_RECONSTRUCTION, false);
         boolean useMarginalLogLikelihood = xo.getAttribute(MARGINAL_LIKELIHOOD, true);
+        boolean conditionalProbabilitiesInLogSpace = xo.getAttribute(CONDITIONAL_PROBABILITIES_IN_LOG_SPACE, false);
+
 
         boolean useUniformization = xo.getAttribute(USE_UNIFORMIZATION, false);
         boolean reportUnconditionedColumns = xo.getAttribute(REPORT_UNCONDITIONED_COLUMNS, false);
@@ -115,7 +117,8 @@ public class MarkovJumpsTreeLikelihoodParser extends AncestralStateTreeLikelihoo
                 useMarginalLogLikelihood,
                 useUniformization,
                 reportUnconditionedColumns,
-                nSimulants
+                nSimulants,
+                conditionalProbabilitiesInLogSpace
         );
 
         int registersFound = parseAllChildren(xo, treeLikelihood, dataType.getStateCount(), jumpTag,


### PR DESCRIPTION
We were running into numerical errors that were triggered by the logger when analysing  big trees with Markov Jumps. The error was caused by multiplying very small probabilities in traverseSample(). Converting the probabilities to log space solves the problem. Do you mind taking a look to make sure I haven't missed something in the process?