### PR TITLE
this is the old way and seems broken

### DIFF
--- a/src/dr/inference/distribution/shrinkage/JointBayesianBridgeDistributionModel.java
+++ b/src/dr/inference/distribution/shrinkage/JointBayesianBridgeDistributionModel.java
@@ -67,7 +67,7 @@ public class JointBayesianBridgeDistributionModel extends BayesianBridgeDistribu
         if (slabWidth != null) {
             double ratio = globalLocalProduct / slabWidth.getParameterValue(0);
             globalLocalProduct /= Math.sqrt(1.0 + ratio * ratio);
-            globalLocalProduct = globalLocalProduct * slabWidth.getParameterValue(0);
+            globalLocalProduct = globalLocalProduct;
         }
         return globalLocalProduct;
     }


### PR DESCRIPTION
First pull request (note: I think I did this backwards, the old broken code is in this new branch because I already committed the "fix")

SD did not match with expression in Shrinkage with Shrunken Shoulders, but multiplying by slab width makes it match.