### PR TITLE
Update LogCombiner.java

### DIFF
--- a/src/dr/app/tools/LogCombiner.java
+++ b/src/dr/app/tools/LogCombiner.java
@@ -209,7 +209,7 @@ public class LogCombiner {
                         line = reader.readLine();
                     }
 
-                    Pattern pattern = Pattern.compile("tree STATE_(\\d+)\\s(.*)");
+                    Pattern pattern = Pattern.compile("tree STATE_(\\d+)(\\s.*)");
 
                     while (line != null) {
                         Matcher m = pattern.matcher(line);


### PR DESCRIPTION
Maintains space in tree string output, might need to be a star after the space in the regex