### PR TITLE
MC^3 bugfixes

### DIFF
--- a/src/dr/app/beast/BeastMain.java
+++ b/src/dr/app/beast/BeastMain.java
@@ -195,6 +195,17 @@ public class BeastMain {
 
                     parser = new BeastParser(new String[]{fileName}, additionalParsers, verbose, parserWarning, strictXML, version);
 
+                    // DM: Hot chains also need to add plugin parsers
+                    for (String pluginName : PluginLoader.getAvailablePlugins()) {
+                        Plugin plugin = PluginLoader.loadPlugin(pluginName);
+                        if (plugin != null) {
+                            Set<XMLObjectParser> parserSet = plugin.getParsers();
+                            for (XMLObjectParser pluginParser : parserSet) {
+                                parser.addXMLObjectParser(pluginParser);
+                            }
+                        }
+                    }
+
                     chains[i] = (MCMC) parser.parse(fileReader, MCMC.class);
                     if (chains[i] == null) {
                         throw new dr.xml.XMLParseException("BEAST XML file is missing an MCMC element");
@@ -915,7 +926,7 @@ public class BeastMain {
             BeastMPI.Finalize();
         }
 
-        if (!window) {
+        if (!usingMC3 && !window) { // DM: with MC3 the main thread gets here and terminates all threads prematurely 
             System.exit(0);
         }
     }

--- a/src/dr/inference/mcmcmc/MCMCMCRunner.java
+++ b/src/dr/inference/mcmcmc/MCMCMCRunner.java
@@ -51,19 +51,21 @@ public class MCMCMCRunner extends Thread {
 
 	        chainDone();
 
-	        if (i < totalLength) {
-		        while (isChainDone()) {
-			        try {
-				        synchronized(this) {
-					        wait();
-				        }
-			        } catch (InterruptedException e) {
-				        // continue...
-			        }
-		        }
-	        }
+            if (i < totalLength) {
+                synchronized(this) {
+                    while (isChainDone()) { //DM. This test needs to be synchronized too. Otherwise, there is a nonzero chance that the MCMCMC.run thread calls continueChain, setting this.chainDone=false and notifies the thread to continue right before it starts listening, making the MC3 hang forever 
+                        try {
+                            //synchronized(this) {
+                                wait();
+                            //}
+                        } catch (InterruptedException e) {
+                            // continue...
+                        }
+                    }
+                }
+            }
         }
-	}
+    }
 
 	private synchronized void chainDone() {
 		chainDone = true;


### PR DESCRIPTION
MC^3 was not working properly on my system since at least Beast v1.8.4. I put together 3 minor changes that solve the issues I was having. I tested these modifications in v1.8.4 and the HEAD of the master branch and it seems to work well in two systems (Mac and Linux).

Issues this pull request solves: 
1) MC3 was killed almost immediately by the main thread reaching the end of BeastMain
2) MC3 would eventually hang forever with all threads sleeping/waiting due to an issue synchronizing threads
3) Pluging parsers were not being loaded in the hot chains/threads

I do not know how much interest you guys have in MC3, but I thought to share these changes just in case you find them useful.