### PR TITLE
epochal discrete CTMC model bug fixes

### DIFF
--- a/src/dr/evomodel/branchmodel/BranchModel.java
+++ b/src/dr/evomodel/branchmodel/BranchModel.java
@@ -43,7 +43,7 @@ import java.util.List;
 public interface BranchModel extends Model  {
     /**
      * Returns a mapping of substitution models to the given branch. The Mapping
-     * contains a list of substitution models in order from tipward to rootward
+     * contains a list of substitution models in order from rootward to tipward
      * and a set of relative weights for each (may be times or proportions).
      *
      * @param branch the branch

--- a/src/dr/evomodel/branchmodel/EpochBranchModel.java
+++ b/src/dr/evomodel/branchmodel/EpochBranchModel.java
@@ -96,9 +96,10 @@ public class EpochBranchModel extends AbstractModel implements BranchModel, Cita
 
         // find the epoch that the parent height is in...
         while (epoch < epochCount && parentHeight >= transitionTimes[epoch]) {
-            // insert each epoch to the list so that it is ordered from parent to child
+            // insert each epoch that this branch overlaps with to the list so that 
+            // it is ordered from parent (rootward) to child (tipward)
             // as the transition probability matrix of a given branch is the product
-            // of matrices multiplying from parent to child
+            // of matrices multiplying from parent to child (Eq. 7 of Bielejec et al., 2014)
             weightList.add( 0, transitionTimes[epoch] - currentHeight );
             orderList.add(0, epoch);
 

--- a/src/dr/evomodel/branchmodel/EpochBranchModel.java
+++ b/src/dr/evomodel/branchmodel/EpochBranchModel.java
@@ -205,6 +205,7 @@ public class EpochBranchModel extends AbstractModel implements BranchModel, Cita
     private final Parameter epochTimes;
 
     public void setRootFrequencyModel(FrequencyModel rootFreqModel) {
+        addModel(rootFreqModel);
         this.rootFrequencyModel = rootFreqModel;
     }
 

--- a/src/dr/evomodel/branchmodel/EpochBranchModel.java
+++ b/src/dr/evomodel/branchmodel/EpochBranchModel.java
@@ -96,16 +96,19 @@ public class EpochBranchModel extends AbstractModel implements BranchModel, Cita
 
         // find the epoch that the parent height is in...
         while (epoch < epochCount && parentHeight >= transitionTimes[epoch]) {
-            weightList.add( transitionTimes[epoch] - currentHeight );
-            orderList.add(epoch);
+            // insert each epoch to the list so that it is ordered from parent to child
+            // as the transition probability matrix of a given branch is the product
+            // of matrices multiplying from parent to child
+            weightList.add( 0, transitionTimes[epoch] - currentHeight );
+            orderList.add(0, epoch);
 
             currentHeight = transitionTimes[epoch];
 
             epoch ++;
         }
 
-        weightList.add( parentHeight - currentHeight );
-        orderList.add(epoch);
+        weightList.add( 0, parentHeight - currentHeight );
+        orderList.add(0, epoch);
 
 
         if (orderList.size() == 0) {

--- a/src/dr/evomodel/tree/EmpiricalTreeDistributionModel.java
+++ b/src/dr/evomodel/tree/EmpiricalTreeDistributionModel.java
@@ -85,10 +85,12 @@ public class EmpiricalTreeDistributionModel extends DefaultTreeModel {
 
     protected void storeState() {
         storedCurrentTree = currentTree;
+        storedCurrentTreeIndex = currentTreeIndex;
     }
 
     protected void restoreState() {
         currentTree = storedCurrentTree;
+        currentTreeIndex = storedCurrentTreeIndex;
     }
 
     protected void acceptState() {
@@ -276,4 +278,5 @@ public class EmpiricalTreeDistributionModel extends DefaultTreeModel {
     private Tree storedCurrentTree;
 
     private int currentTreeIndex;
+    private int storedCurrentTreeIndex;
 }


### PR DESCRIPTION
This pull request contains a few bug-fix commits related to the epochal branch model. The second and third commits (`f635eb0` and `9f7df12`) are quite minor (both in terms of the consequences and the changes made) and hopefully can be self-explanatory, so I'll focus on the first commit (while the fourth commit simply involves some comment edits that I forgot to make in the first commit) here.

The first commit (`59fc185`) attempts to fix an issue with the order of matrices fetched by the getBranchModelMapping function. This function is a member of the `EpochalBranchModel` class, which implements a model where the a discrete CTMC (substitution or dispersal) model can vary over time epochs. When a branch overlaps with multiple time epochs, the transition-probability (P) matrix of this branch is computed as the product (i.e., convolution) of epochal P matrices along the branch ([Eg. 7 of Bielejec et al., 2014](https://academic.oup.com/sysbio/article/63/4/493/2848077#M7)). In the convolution, these P matrices should be ordered from the parent node to the child node.

It seems that the current implementation instead ordered the matrices from child to parent in the `getBranchModelMapping` function, and there doesn't seem to involve any reversal of the order after invoking the function (judging from the `updateTransitionMatrices` and `convolveMatrices` functions of the `SubstitutionModelDelegate` class). Accordingly, I edited the `getBranchModelMapping` function so that it returns an epochal-model mapping ordered from parent to child along a branch.

This is my first time submitting a pull request to BEAST; please let me know if I misinterpreted anything or failed to follow the preferred coding style in my edits. Thank you in advance for reviewing this PR.