### PR TITLE
asymmetric Q matrix normalization extension

### DIFF
--- a/src/dr/evomodel/substmodel/BaseSubstitutionModel.java
+++ b/src/dr/evomodel/substmodel/BaseSubstitutionModel.java
@@ -279,10 +279,14 @@ public abstract class BaseSubstitutionModel extends AbstractModel
 
     protected double setupMatrix() {
         setupRelativeRates(relativeRates);
-        double[] pi = freqModel.getFrequencies();
+        double[] pi = getPi();
         setupQMatrix(relativeRates, pi, q);
         makeValid(q, stateCount);
         return getNormalizationValue(q, pi);
+    }
+
+    protected double[] getPi() {
+        return freqModel.getFrequencies();
     }
 
     public void getInfinitesimalMatrix(double[] out) {

--- a/src/dr/evomodel/substmodel/ComplexSubstitutionModel.java
+++ b/src/dr/evomodel/substmodel/ComplexSubstitutionModel.java
@@ -25,6 +25,11 @@
 
 package dr.evomodel.substmodel;
 
+import cern.colt.matrix.DoubleMatrix2D;
+import cern.colt.matrix.impl.DenseDoubleMatrix2D;
+import cern.colt.matrix.linalg.Algebra;
+import cern.colt.matrix.linalg.LUDecomposition;
+
 import dr.evolution.datatype.DataType;
 import dr.inference.loggers.LogColumn;
 import dr.inference.loggers.NumberColumn;
@@ -32,6 +37,7 @@ import dr.inference.model.BayesianStochasticSearchVariableSelection;
 import dr.inference.model.Likelihood;
 import dr.inference.model.Model;
 import dr.inference.model.Parameter;
+import dr.inference.model.Variable;
 import dr.math.matrixAlgebra.Vector;
 import dr.util.Citable;
 import dr.util.Citation;
@@ -47,6 +53,11 @@ public class ComplexSubstitutionModel extends GeneralSubstitutionModel implement
     public ComplexSubstitutionModel(String name, DataType dataType, FrequencyModel freqModel, Parameter parameter) {
         super(name, dataType, freqModel, parameter, -1);
         probability = new double[stateCount * stateCount];
+        
+        stationaryDistribution = new double[stateCount];
+        storedStationaryDistribution = new double[stateCount];
+        stationaryDistributionKnown = false;
+        storedStationaryDistributionKnown = false;
     }
 
     @Override
@@ -73,6 +84,42 @@ public class ComplexSubstitutionModel extends GeneralSubstitutionModel implement
 
     protected EigenSystem getDefaultEigenSystem(int stateCount) {
         return new ComplexColtEigenSystem(stateCount);
+    }
+
+    private void computeStationaryDistribution(double[] statDistr) {
+        // Uses an LU decomposition to solve Q^t \pi = 0 and \sum \pi_i = 1
+
+        double[][] mat = getRelativeRateMatrix();
+        DoubleMatrix2D mat2 = new DenseDoubleMatrix2D(stateCount + 1, stateCount);
+        for (int i = 0; i < stateCount; ++i) {
+            for (int j = 0; j < stateCount; ++j) {
+                mat2.set(j, i, mat[i][j]); // Transposed
+            }
+        }
+        // Add row for sum-to-one constraint
+        for (int i = 0; i < stateCount; ++i) {
+            mat2.set(stateCount, i, 1.0);
+        }
+
+        LUDecomposition decomp = new LUDecomposition(mat2);
+        DoubleMatrix2D x = new DenseDoubleMatrix2D(stateCount + 1, 1);
+        x.set(stateCount, 0, 1.0);
+        DoubleMatrix2D y = decomp.solve(x);
+        for (int i = 0; i < stateCount; ++i) {
+            statDistr[i] = y.get(i, 0);
+        }
+    }
+    
+    protected double[] getPi() {
+        return getFrequencies();
+    }
+    
+    public double[] getFrequencies() {
+        if (!stationaryDistributionKnown) {
+            computeStationaryDistribution(stationaryDistribution);
+            stationaryDistributionKnown = true;
+        }
+        return stationaryDistribution;
     }
 
     /**
@@ -163,13 +210,22 @@ public class ComplexSubstitutionModel extends GeneralSubstitutionModel implement
             rates[i] = ratesParameter.getParameterValue(i);
     }
 
+    protected double[][] getRelativeRateMatrix() {
+        setupRelativeRates(relativeRates);
+        double[][] mat = new double[stateCount][stateCount];
+        setupQMatrix(relativeRates, null, mat);
+        makeValid(mat, stateCount);
+        return mat;
+    }
+
     protected void setupQMatrix(double[] rates, double[] pi, double[][] matrix) {
         int i, j, k = 0;
         for (i = 0; i < stateCount; i++) {
             for (j = i + 1; j < stateCount; j++) {
                 double thisRate = rates[k++];
                 if (thisRate < 0.0) thisRate = 0.0;
-                matrix[i][j] = thisRate * pi[j];
+//                matrix[i][j] = thisRate * pi[j];
+                matrix[i][j] = thisRate;
             }
         }
         // Copy lower triangle in column-order form (transposed)
@@ -177,7 +233,8 @@ public class ComplexSubstitutionModel extends GeneralSubstitutionModel implement
             for (i = j + 1; i < stateCount; i++) {
                 double thisRate = rates[k++];
                 if (thisRate < 0.0) thisRate = 0.0;
-                matrix[i][j] = thisRate * pi[j];
+//                matrix[i][j] = thisRate * pi[j];
+                matrix[i][j] = thisRate;
             }
         }
     }
@@ -204,6 +261,27 @@ public class ComplexSubstitutionModel extends GeneralSubstitutionModel implement
         if (BayesianStochasticSearchVariableSelection.Utils.connectedAndWellConditioned(probability, this))
             return 0;
         return Double.NEGATIVE_INFINITY;
+    }
+
+    protected void handleVariableChangedEvent(Variable variable, int index, Parameter.ChangeType type) {
+        stationaryDistributionKnown = false;
+        super.handleVariableChangedEvent(variable, index, type);
+    }
+    
+    protected void storeState() {
+        System.arraycopy(stationaryDistribution, 0, storedStationaryDistribution, 0, stateCount);
+        storedStationaryDistributionKnown = stationaryDistributionKnown;
+        
+        super.storeState();
+    }
+    
+    protected void restoreState() {
+        double[] tmp = stationaryDistribution;
+        stationaryDistribution = storedStationaryDistribution;
+        storedStationaryDistribution = tmp;
+        stationaryDistributionKnown = storedStationaryDistributionKnown;
+
+        super.restoreState();
     }
 
     /**
@@ -303,4 +381,9 @@ public class ComplexSubstitutionModel extends GeneralSubstitutionModel implement
     }
 
     private boolean doNormalization = true;
+
+    private double[] stationaryDistribution;
+    private double[] storedStationaryDistribution;
+    private boolean stationaryDistributionKnown;
+    private boolean storedStationaryDistributionKnown;
 }

--- a/src/dr/evomodel/substmodel/GeneralSubstitutionModel.java
+++ b/src/dr/evomodel/substmodel/GeneralSubstitutionModel.java
@@ -115,6 +115,10 @@ public class GeneralSubstitutionModel extends BaseSubstitutionModel {
         ratesParameter.setDimensionNames(rateNames.toArray(tmp));
     }
 
+    public void setNormalization(boolean doNormalization) {
+        this.doNormalization = doNormalization;
+    }
+
     protected String getDimensionString(int i, int j, String prefix) {
         String codes =  dataType.getCode(i) + "." + dataType.getCode(j);
         if (prefix == null) {
@@ -122,6 +126,14 @@ public class GeneralSubstitutionModel extends BaseSubstitutionModel {
         } else {
             return prefix + "." + codes;
         }
+    }
+
+    protected double getNormalizationValue(double[][] matrix, double[] pi) {
+        double norm = 1.0;
+        if (doNormalization) {
+            norm = super.getNormalizationValue(matrix, pi);
+        }
+        return norm;
     }
 
     /**
@@ -155,4 +167,5 @@ public class GeneralSubstitutionModel extends BaseSubstitutionModel {
      */
 
     protected Parameter ratesParameter = null;
+    private boolean doNormalization = true;
 }

--- a/src/dr/evomodelxml/substmodel/ComplexSubstitutionModelParser.java
+++ b/src/dr/evomodelxml/substmodel/ComplexSubstitutionModelParser.java
@@ -51,6 +51,7 @@ public class ComplexSubstitutionModelParser extends AbstractXMLObjectParser {
     public static final String BSSVS_SCALAR = "bssvsScalar";
     public static final String CHECK_CONDITIONING = "checkConditioning";
     public static final String NORMALIZED = "normalized";
+    public static final String COMPUTE_STATIONARY = "computeStationary";
 
     public static final int maxRandomizationTries = 100;
 
@@ -72,9 +73,11 @@ public class ComplexSubstitutionModelParser extends AbstractXMLObjectParser {
         if (xo.hasChildNamed(FREQUENCIES)) {
             cxo = xo.getChild(FREQUENCIES);
             freqModel = (FrequencyModel) cxo.getChild(FrequencyModel.class);
-        } else if (xo.hasChildNamed(ROOT_FREQUENCIES)){
+        } else if (xo.hasChildNamed(ROOT_FREQUENCIES)) {
             cxo = xo.getChild(ROOT_FREQUENCIES);
             freqModel = (FrequencyModel) cxo.getChild(FrequencyModel.class);
+        } else if (!xo.getAttribute(COMPUTE_STATIONARY, false)) {
+            throw new XMLParseException("No frequency model found in " + getParserName());
         }
 //        FrequencyModel freqModel = (FrequencyModel) cxo.getChild(FrequencyModel.class);
 //        DataType dataType = freqModel.getDataType();
@@ -215,5 +218,6 @@ public class ComplexSubstitutionModelParser extends AbstractXMLObjectParser {
             AttributeRule.newDoubleRule(BSSVS_SCALAR, true),
             AttributeRule.newBooleanRule(CHECK_CONDITIONING, true),
             AttributeRule.newBooleanRule(NORMALIZED, true),
+            AttributeRule.newBooleanRule(COMPUTE_STATIONARY, true),
     };
 }

--- a/src/dr/evomodelxml/substmodel/ComplexSubstitutionModelParser.java
+++ b/src/dr/evomodelxml/substmodel/ComplexSubstitutionModelParser.java
@@ -27,6 +27,7 @@ package dr.evomodelxml.substmodel;
 
 import dr.evolution.datatype.DataType;
 import dr.evomodel.substmodel.*;
+import dr.evoxml.util.DataTypeUtils;
 import dr.inference.model.BayesianStochasticSearchVariableSelection;
 import dr.inference.model.Parameter;
 import dr.xml.*;
@@ -67,14 +68,18 @@ public class ComplexSubstitutionModelParser extends AbstractXMLObjectParser {
         Parameter ratesParameter;
 
         XMLObject cxo;
+        FrequencyModel freqModel = null;
         if (xo.hasChildNamed(FREQUENCIES)) {
             cxo = xo.getChild(FREQUENCIES);
-        } else {
+            freqModel = (FrequencyModel) cxo.getChild(FrequencyModel.class);
+        } else if (xo.hasChildNamed(ROOT_FREQUENCIES)){
             cxo = xo.getChild(ROOT_FREQUENCIES);
+            freqModel = (FrequencyModel) cxo.getChild(FrequencyModel.class);
         }
-        FrequencyModel freqModel = (FrequencyModel) cxo.getChild(FrequencyModel.class);
+//        FrequencyModel freqModel = (FrequencyModel) cxo.getChild(FrequencyModel.class);
+//        DataType dataType = freqModel.getDataType();
 
-        DataType dataType = freqModel.getDataType();
+        DataType dataType = DataTypeUtils.getDataType(xo);
 
         cxo = xo.getChild(RATES);
 
@@ -197,7 +202,7 @@ public class ComplexSubstitutionModelParser extends AbstractXMLObjectParser {
             AttributeRule.newBooleanRule(RANDOMIZE, true),
             new XORRule(
                     new ElementRule(FREQUENCIES, FrequencyModel.class),
-                    new ElementRule(ROOT_FREQUENCIES, FrequencyModel.class)),
+                    new ElementRule(ROOT_FREQUENCIES, FrequencyModel.class), true),
             new ElementRule(RATES,
                     new XMLSyntaxRule[]{
                             new ElementRule(Parameter.class, true)}

--- a/src/dr/evomodelxml/substmodel/GeneralSubstitutionModelParser.java
+++ b/src/dr/evomodelxml/substmodel/GeneralSubstitutionModelParser.java
@@ -49,6 +49,7 @@ public class GeneralSubstitutionModelParser extends AbstractXMLObjectParser {
     public static final String RELATIVE_TO = "relativeTo";
     public static final String FREQUENCIES = "frequencies";
     public static final String INDICATOR = "rateIndicator";
+    public static final String NORMALIZED = "normalized";
 
     public String getParserName() {
         return GENERAL_SUBSTITUTION_MODEL;
@@ -101,6 +102,8 @@ public class GeneralSubstitutionModelParser extends AbstractXMLObjectParser {
         boolean isNonReversible = ratesParameter.getDimension() == nonReversibleRateCount;
         boolean hasIndicator = xo.hasChildNamed(INDICATOR);
 
+        GeneralSubstitutionModel model;
+
         if (!hasRelativeRates) {
             Parameter indicatorParameter = null;
 
@@ -142,10 +145,10 @@ public class GeneralSubstitutionModelParser extends AbstractXMLObjectParser {
 //                    throw new XMLParseException("Non-reversible model missing " + ROOT_FREQ + " element");
 //                }
                 Logger.getLogger("dr.evomodel").info("  Using BSSVS Complex Substitution Model");
-                return new SVSComplexSubstitutionModel(getParserName(), dataType, freqModel, ratesParameter, indicatorParameter);
+                model = new SVSComplexSubstitutionModel(getParserName(), dataType, freqModel, ratesParameter, indicatorParameter);
             } else {
                 Logger.getLogger("dr.evomodel").info("  Using BSSVS General Substitution Model");
-                return new SVSGeneralSubstitutionModel(getParserName(), dataType, freqModel, ratesParameter, indicatorParameter);
+                model = new SVSGeneralSubstitutionModel(getParserName(), dataType, freqModel, ratesParameter, indicatorParameter);
             }
 
 
@@ -187,8 +190,15 @@ public class GeneralSubstitutionModelParser extends AbstractXMLObjectParser {
                 }
             }
 
-            return new GeneralSubstitutionModel(getParserName(), dataType, freqModel, ratesParameter, relativeTo);
+            model = new GeneralSubstitutionModel(getParserName(), dataType, freqModel, ratesParameter, relativeTo);
         }
+
+        if (!xo.getAttribute(NORMALIZED, true)) {
+            model.setNormalization(false);
+            Logger.getLogger("dr.app.beagle.evomodel").info("\tNormalization: false");
+        }
+
+        return model;
     }
 
     //************************************************************************
@@ -223,5 +233,6 @@ public class GeneralSubstitutionModelParser extends AbstractXMLObjectParser {
                             new ElementRule(Parameter.class),
                     }, true),
             AttributeRule.newBooleanRule(ComplexSubstitutionModelParser.RANDOMIZE,true),
+            AttributeRule.newBooleanRule(NORMALIZED, true),
     };
 }

--- a/src/dr/evomodelxml/substmodel/GeneralSubstitutionModelParser.java
+++ b/src/dr/evomodelxml/substmodel/GeneralSubstitutionModelParser.java
@@ -50,6 +50,7 @@ public class GeneralSubstitutionModelParser extends AbstractXMLObjectParser {
     public static final String FREQUENCIES = "frequencies";
     public static final String INDICATOR = "rateIndicator";
     public static final String NORMALIZED = "normalized";
+    public static final String COMPUTE_STATIONARY = "computeStationary";
 
     public String getParserName() {
         return GENERAL_SUBSTITUTION_MODEL;
@@ -63,6 +64,8 @@ public class GeneralSubstitutionModelParser extends AbstractXMLObjectParser {
         if (xo.hasChildNamed(FREQUENCIES)) {
             XMLObject cxo = xo.getChild(FREQUENCIES);
             freqModel = (FrequencyModel) cxo.getChild(FrequencyModel.class);
+        } else if (!xo.getAttribute(COMPUTE_STATIONARY, false)) {
+            throw new XMLParseException("No frequency model found in " + getParserName());
         }
 
         DataType dataType = DataTypeUtils.getDataType(xo);
@@ -242,5 +245,6 @@ public class GeneralSubstitutionModelParser extends AbstractXMLObjectParser {
                     }, true),
             AttributeRule.newBooleanRule(ComplexSubstitutionModelParser.RANDOMIZE,true),
             AttributeRule.newBooleanRule(NORMALIZED, true),
+            AttributeRule.newBooleanRule(COMPUTE_STATIONARY, true),
     };
 }

--- a/src/dr/evomodelxml/substmodel/GeneralSubstitutionModelParser.java
+++ b/src/dr/evomodelxml/substmodel/GeneralSubstitutionModelParser.java
@@ -82,10 +82,16 @@ public class GeneralSubstitutionModelParser extends AbstractXMLObjectParser {
 //            }
 //        }
 
-        if (dataType == null) dataType = freqModel.getDataType();
+        if (dataType == null && freqModel != null) {
+            dataType = freqModel.getDataType(); 
+        } else if (freqModel != null) {
+           if (dataType != freqModel.getDataType()) {
+                throw new XMLParseException("Data type of " + getParserName() + " element does not match that of its frequencyModel.");
+            }
+        }
 
-        if (dataType != freqModel.getDataType()) {
-            throw new XMLParseException("Data type of " + getParserName() + " element does not match that of its frequencyModel.");
+        if (dataType == null) {
+            throw new XMLParseException("Data type of " + getParserName() + " element can not be found.");
         }
 
         XMLObject cxo = xo.getChild(RATES);
@@ -223,7 +229,9 @@ public class GeneralSubstitutionModelParser extends AbstractXMLObjectParser {
                             DataType.getRegisteredDataTypeNames(), false),
                     new ElementRule(DataType.class)
                     , true),
-            new ElementRule(FREQUENCIES, FrequencyModel.class),
+            new ElementRule(FREQUENCIES, 
+                    new XMLSyntaxRule[]{
+                            new ElementRule(FrequencyModel.class)}, true),
             new ElementRule(RATES,
                     new XMLSyntaxRule[]{
                             new ElementRule(Parameter.class)}


### PR DESCRIPTION
This PR is modified from a [previous PR](https://github.com/beast-dev/beast-mcmc/pull/1130) following @msuchard's suggestion. It contains two additional commits to revert to the default behavior of `ComplexSubstitutionModel` that (1) uses the explicitly specified frequency vector to normalize the matrix (commit `7f5523b`) and (2) require a `frequencies` or `rootfrequencies` object to be provided within a `ComplexSubstitutionModel` block in the XML (commit `0ef84bc`). After these changes, only when a newly added argument `computeStationary` is specified to true (default false) and no frequency vector is provided within the `ComplexSubstitutionModel` block, the stationary distribution will be computed from the asymmetric Q matrix and be used to normalize the matrix (otherwise the old behavior is untouched and is the default).

For the sake of completeness, the PR message from the previous PR is included below.

> This pull request contains three commits that allow a more flexible construction and normalization of a `ComplexSubstitutionModel`-class Q matrix. The `ComplexSubstitutionModel` implements an asymmetric Q matrix that is time irreversible ([Edwards et al., 2011](https://www.sciencedirect.com/science/article/pii/S0960982211006452)). This time-irreversible Q matrix can still have a stationary distribution (which is necessarily nonuniform) as long as the matrix is irreducible, but, unlike a GTR model, it seems more sensible and conventional to construct the matrix (at least optionally) without specifying the stationary frequency vector as a constant or stochastic variable.
> 
> The first commit (`77b201b`) modified the normalization behavior of a ComplexSubstitutionModel-class Q matrix so that a stationary distribution is computed from the matrix first and then used to normalize the matrix (instead of normalizing using a constant or stochastic frequency vector specified in the XML, which is necessarily not the stationary distribution as the matrix updates in the MCMC). The core code in this commit for computing the stationary distribution is modified (slightly) from the same function of the `MarkovModulatedFrequencyModel` class. 
> 
> The second commit (`4c91cf1`) fixes a minor issue so that the 'normalized' argument can be passed correctly to the back end. The third commit (`b5d7cc8`) makes the `frequencies` (and `rootfrequencies`) argument optional in the XML.
 
Please let me know if any edits are needed to these commits. Thank you in advance for reviewing this PR.