### PR TITLE
extending the epochal discrete CTMC model

### DIFF
--- a/src/dr/app/beagle/tools/Partition.java
+++ b/src/dr/app/beagle/tools/Partition.java
@@ -150,7 +150,7 @@ public class Partition {
 
 	private void setSubstitutionModelDelegate() {
 		substitutionModelDelegate = new SubstitutionModelDelegate(treeModel,
-				branchModel);
+				branchModel, branchRateModel);
 	}// END: setSubstitutionModelDelegate
 
 	private void setBufferHelpers() {

--- a/src/dr/evomodel/branchmodel/EpochBranchModel.java
+++ b/src/dr/evomodel/branchmodel/EpochBranchModel.java
@@ -92,7 +92,7 @@ public class EpochBranchModel extends AbstractModel implements BranchModel, Cita
         double currentHeight = nodeHeight;
 
         // find the epoch that the parent height is in...
-        while (epoch < epochCount && parentHeight >= transitionTimes[epoch]) {
+        while (epoch < epochCount && parentHeight > transitionTimes[epoch]) {
             weightList.add( transitionTimes[epoch] - currentHeight );
             orderList.add(epoch);
 

--- a/src/dr/evomodel/branchratemodel/AbstractBranchRateModel.java
+++ b/src/dr/evomodel/branchratemodel/AbstractBranchRateModel.java
@@ -84,4 +84,17 @@ public abstract class AbstractBranchRateModel extends AbstractModelLikelihood im
     public void makeDirty() {
         // Do nothing
     }
+    
+    public Mapping getBranchRateModelMapping(final Tree tree, final NodeRef node) {
+        
+        return new Mapping() {
+            public double[] getRates() {
+                return new double[] { getBranchRate(tree, node) };
+            }
+
+            public double[] getWeights() {
+                return new double[] { 1.0 };
+            }
+        };
+    }
 }

--- a/src/dr/evomodel/branchratemodel/BranchRateModel.java
+++ b/src/dr/evomodel/branchratemodel/BranchRateModel.java
@@ -41,4 +41,29 @@ public interface BranchRateModel extends Model, BranchRates, TreeTraitProvider, 
 
     // This is inherited from BranchRates:
     // double getBranchRate(Tree tree, NodeRef node);
+    
+     /**
+     * Returns a mapping of branch rate models to the given branch. The Mapping
+     * contains a list of branch rates in order from rootward to tipward
+     * and a set of relative weights for each (may be times or proportions).
+     *
+     * @param branch the branch
+     * @return a Mapping object
+     */
+    Mapping getBranchRateModelMapping(final Tree tree, final NodeRef branch);
+    
+    interface Mapping {
+        double[] getRates();
+        double[] getWeights();
+    }
+
+    Mapping DEFAULT = new Mapping() {
+        public double[] getRates() {
+            return new double[] { 1.0 };
+        }
+
+        public double[] getWeights() {
+            return new double[] { 1.0 };
+        }
+    };
 }

--- a/src/dr/evomodel/branchratemodel/DefaultBranchRateModel.java
+++ b/src/dr/evomodel/branchratemodel/DefaultBranchRateModel.java
@@ -41,6 +41,10 @@ public final class DefaultBranchRateModel implements BranchRateModel, Differenti
     public double getBranchRate(Tree tree, NodeRef node) {
         return 1.0;
     }
+    
+    public Mapping getBranchRateModelMapping(final Tree tree, final NodeRef node) {
+        return DEFAULT;
+    }
 
     public void addModelListener(ModelListener listener) {
         // nothing to do

--- a/src/dr/evomodel/branchratemodel/LatentStateBranchRateModel.java
+++ b/src/dr/evomodel/branchratemodel/LatentStateBranchRateModel.java
@@ -184,6 +184,20 @@ public class LatentStateBranchRateModel extends AbstractModelLikelihood implemen
 
         return calculateBranchRate(nonLatentRate, latentProportion);
     }
+    
+    @Override
+    public Mapping getBranchRateModelMapping(final Tree tree, final NodeRef node) {
+        
+        return new Mapping() {
+            public double[] getRates() {
+                return new double[] { getBranchRate(tree, node) };
+            }
+
+            public double[] getWeights() {
+                return new double[] { 1.0 };
+            }
+        };
+    }
 
     public double getLatentProportion(Tree tree, NodeRef node) {
 

--- a/src/dr/evomodel/branchratemodel/SericolaLatentStateBranchRateModel.java
+++ b/src/dr/evomodel/branchratemodel/SericolaLatentStateBranchRateModel.java
@@ -183,6 +183,20 @@ public class SericolaLatentStateBranchRateModel extends AbstractModelLikelihood 
 
         return calculateBranchRate(nonLatentRate, latentProportion);
     }
+    
+    @Override
+    public Mapping getBranchRateModelMapping(final Tree tree, final NodeRef node) {
+        
+        return new Mapping() {
+            public double[] getRates() {
+                return new double[] { getBranchRate(tree, node) };
+            }
+
+            public double[] getWeights() {
+                return new double[] { 1.0 };
+            }
+        };
+    }
 
     public double getLatentProportion(Tree tree, NodeRef node) {
 

--- a/src/dr/evomodel/substmodel/UniformizedSubstitutionModel.java
+++ b/src/dr/evomodel/substmodel/UniformizedSubstitutionModel.java
@@ -128,16 +128,20 @@ public class UniformizedSubstitutionModel extends MarkovJumpsSubstitutionModel {
         return getCompleteHistory(null, null);
     }
 
-   public String getCompleteHistory(Double newStartTime, Double newEndTime) {
+    public String getCompleteHistory(Double newStartTime, Double newEndTime) {
         return getCompleteHistory(-1, newStartTime, newEndTime);
-   }
+    }
 
     public String getCompleteHistory(int site, Double newStartTime, Double newEndTime) {
+        return getCompleteHistory(site, newStartTime, newEndTime, true);
+    }
+
+    public String getCompleteHistory(int site, Double newStartTime, Double newEndTime, boolean wrap) {
         if (newStartTime != null && newEndTime != null) {
             // Rescale time of events
             completeHistory.rescaleTimesOfEvents(newStartTime, newEndTime);
         }
-        return completeHistory.toStringChanges(site, dataType); //, 0.0);
+        return completeHistory.toStringChanges(site, dataType, wrap); //, 0.0);
     }
 
     public int getNumberOfJumpsInCompleteHistory() {

--- a/src/dr/evomodel/treelikelihood/BeagleTreeLikelihood.java
+++ b/src/dr/evomodel/treelikelihood/BeagleTreeLikelihood.java
@@ -207,7 +207,7 @@ public class BeagleTreeLikelihood extends AbstractSinglePartitionTreeLikelihood 
             if (extraBufferOrder.size() > 0) {
                 extraBufferCount = extraBufferOrder.get(instanceCount % extraBufferOrder.size());
             }
-            substitutionModelDelegate = new SubstitutionModelDelegate(treeModel, branchModel, extraBufferCount);
+            substitutionModelDelegate = new SubstitutionModelDelegate(treeModel, branchModel, branchRateModel, extraBufferCount);
 
             // first set the rescaling scheme to use from the parser
             this.rescalingScheme = rescalingScheme;

--- a/src/dr/evomodel/treelikelihood/MultiPartitionTreeLikelihood.java
+++ b/src/dr/evomodel/treelikelihood/MultiPartitionTreeLikelihood.java
@@ -197,7 +197,7 @@ public class MultiPartitionTreeLikelihood extends AbstractTreeLikelihood impleme
 
             substitutionModelDelegates = new SubstitutionModelDelegate[partitionCount];
             for (int i = 0; i < partitionCount; i++) {
-                substitutionModelDelegates[i] = new SubstitutionModelDelegate(treeModel, branchModel, extraBufferCount);
+                substitutionModelDelegates[i] = new SubstitutionModelDelegate(treeModel, branchModel, branchRateModel, extraBufferCount);
             }
 
             // first set the rescaling scheme to use from the parser


### PR DESCRIPTION
This PR is modified from a [previous PR](https://github.com/beast-dev/beast-mcmc/pull/1129) following @msuchard's suggestion. One of the commits (commit `859f33f`) contained in this pull request has been fully revised to remove the unnecessary code duplication caused by the (trivial version of) `getBranchRateModelMapping ` function copied across all the `branchratemodel` classes (now the trivial version of this function is implemented in the AbstractBranchRateModel class so this function has been removed from all the branchRate classes extending the abstract class). (The other two commits in this PR remain unchanged.)

I have done an additional experiment to validate the implementation extension contained in this pull request. Please see this [synopsis.pdf](https://github.com/beast-dev/beast-mcmc/files/9050875/synopsis.pdf) document for a brief summary of the experiment. (The supplementary files that I used to perform this experiment is available in this [Qmu_bothvary_test.zip](https://github.com/beast-dev/beast-mcmc/files/9050877/Qmu_bothvary_test.zip) folder).

Please let me know if there is anything unclear or missing in the experiment. I have also changed the target branch of this pull request to `hmc-clock` as advised. Thanks again for reviewing this PR.

For the sake of completeness, the PR message from the previous PR is included below.

> This pull request contains three commits that extend the epochal discrete CTMC (substitution/dispersal) model. Specifically, this extension allows the transition-probability (P) matrix to be computed correctly along a branch that overlaps with multiple Q-matrix epochs ([Bielejec et al., 2014](https://academic.oup.com/sysbio/article/63/4/493/2848077)) and multiple average-substitution/dispersal-rate epochs ([Membrebe et al., 2019](https://academic.oup.com/mbe/article/36/8/1793/5475507)), and the stochastic-mapping function (the endpoint-conditioned uniformization algorithm; [Hobolth and Stone, 2009](https://projecteuclid.org/journals/annals-of-applied-statistics/volume-3/issue-3/Simulation-from-endpoint-conditioned-continuous-time-Markov-chains-on-a/10.1214/09-AOAS247.full)) to work under the epochal model (either epochal matrices or epochal rates or both). A more detailed description about the extension can be found in S1 (S1.1 for the P-matrix computation and S1.2 for the stochastic-mapping function) of [Gao et al., 2021](https://www.medrxiv.org/content/10.1101/2021.12.02.21267221v1.supplementary-material).
> 
> The first commit (`94e91fe`) added a `getBranchRateModelMapping` function to each `BranchRateModel` class (where the only non-trivial implementation is in the `RateEpochBranchRateModel` class), imitating the `getBranchModelMapping` function of the `BranchModel` classes. 
> 
> In the second commit (`e86792c`), this added mapping function is invoked in the `SubstitutionModelDelegate` class very similarly as the `getBranchModelMapping` function, allowing the average rate of each Q-matrix epoch that overlaps with a given branch to be computed correctly (instead of assuming that it is the average rate of the entire branch). 
> 
> The third commit (`9e81125`) extends the endpoint-conditioned uniformization algorithm to work under the epochal model by (1) dividing a branch into pieces (where each piece only overlaps with one Q-matrix epoch and one average-rate epoch), (2) drawing the state at the end of each piece according to the probability conditioned on the start state of the piece and the end state of the branch, and (3) simulating history over each piece using the time-homogeneous algorithm.
> 
> Please let me know if I failed to follow the preferred coding style in this extension or if some of the functionalities introduced here would be preferred to be implemented in an alternative way. Thank you in advance for reviewing this PR.