### PR TITLE
fixes ant compile error when default encoding is ASCII

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -74,7 +74,8 @@
                fork="true"
                includeantruntime="false"
                memoryinitialsize="256m"
-               memorymaximumsize="1024m">
+               memorymaximumsize="1024m"
+               encoding="UTF-8">
             <include name="dr/app/beast/**"/>
             <include name="dr/app/beauti/**"/>
             <include name="dr/app/bss/**"/>


### PR DESCRIPTION
I ran into some issues compiling with ant related to javac assuming ASCII text encoding. I'm sure there's a way to fix the ant/javac options elsewhere, but this seemed like a reasonable alternative that should avoid similar problems without people having to individually modify their local environments.