### PR TITLE
Keep calculation of the determinant in log-scale

### DIFF
--- a/src/dr/evomodel/continuous/IntegratedMultivariateTraitLikelihood.java
+++ b/src/dr/evomodel/continuous/IntegratedMultivariateTraitLikelihood.java
@@ -402,7 +402,7 @@ public abstract class IntegratedMultivariateTraitLikelihood extends AbstractMult
                 System.err.println("Conditional root MVN precision = \n" + new Matrix(T));
                 System.err.println("Conditional root MVN density = " + MultivariateNormalDistribution.logPdf(
                         conditionalRootMean, new double[dimTrait], T,
-                        Math.log(MultivariateNormalDistribution.calculatePrecisionMatrixDeterminate(T)), 1.0));
+                        MultivariateNormalDistribution.calculatePrecisionMatrixLogDeterminate(T), 1.0));
             }
 
             if (integrateRoot) {

--- a/src/dr/evomodel/continuous/MultivariateDiffusionModel.java
+++ b/src/dr/evomodel/continuous/MultivariateDiffusionModel.java
@@ -149,8 +149,8 @@ public class MultivariateDiffusionModel extends AbstractModel implements TreeAtt
     protected void calculatePrecisionInfo() {
         diffusionPrecisionMatrix = diffusionPrecisionMatrixParameter.getParameterAsMatrix();
         determinatePrecisionMatrix =
-                MultivariateNormalDistribution.calculatePrecisionMatrixDeterminate(
-                        diffusionPrecisionMatrix);
+                Math.exp(MultivariateNormalDistribution.calculatePrecisionMatrixLogDeterminate(
+                        diffusionPrecisionMatrix));
     }
 
     // *****************************************************************

--- a/src/dr/inference/operators/RegressionMetropolizedIndicatorOperator.java
+++ b/src/dr/inference/operators/RegressionMetropolizedIndicatorOperator.java
@@ -85,7 +85,7 @@ public class RegressionMetropolizedIndicatorOperator extends SimpleMCMCOperator 
         effectOperator.computeForwardDensity(mean, variance,precision);
         logHastingsRatio += MultivariateNormalDistribution.logPdf(effect.getParameterValues(),
                                 mean, precision,
-                                Math.log(MultivariateNormalDistribution.calculatePrecisionMatrixDeterminate(precision)),
+                                MultivariateNormalDistribution.calculatePrecisionMatrixLogDeterminate(precision),
                                 1.0);
 
         // Do update
@@ -104,7 +104,7 @@ public class RegressionMetropolizedIndicatorOperator extends SimpleMCMCOperator 
         precision = effectOperator.getLastPrecision();
         logHastingsRatio -= MultivariateNormalDistribution.logPdf(effect.getParameterValues(),
                                 mean, precision,
-                                Math.log(MultivariateNormalDistribution.calculatePrecisionMatrixDeterminate(precision)),
+                                MultivariateNormalDistribution.calculatePrecisionMatrixLogDeterminate(precision),
                                 1.0);
 
         return logHastingsRatio;

--- a/src/dr/math/distributions/MultivariateNormalDistribution.java
+++ b/src/dr/math/distributions/MultivariateNormalDistribution.java
@@ -91,8 +91,7 @@ public class MultivariateNormalDistribution implements MultivariateDistribution,
 
     public double getLogDet() {
         if (logDet == null) {
-            boolean inlogScale = true;
-            logDet = calculatePrecisionMatrixDeterminate(precision, inlogScale);
+            logDet = calculatePrecisionMatrixLogDeterminate(precision);
         }
         if (Double.isInfinite(logDet)) {
             if (isDiagonal(precision)) {
@@ -148,18 +147,9 @@ public class MultivariateNormalDistribution implements MultivariateDistribution,
         nextMultivariateNormalCholesky(mean, getCholeskyDecomposition(), Math.sqrt(scale), result);
     }
 
-    public static double calculatePrecisionMatrixDeterminate(double[][] precision) {
-        boolean inLogScale = false;
-        return calculatePrecisionMatrixDeterminate(precision, inLogScale);
-    }
-
-    public static double calculatePrecisionMatrixDeterminate(double[][] precision, boolean inLogScale) {
+    public static double calculatePrecisionMatrixLogDeterminate(double[][] precision) {
         try {
-            if (inLogScale) {
-                return new Matrix(precision).logDeterminant();
-            } else {
-                return new Matrix(precision).determinant();
-            }
+            return new Matrix(precision).logDeterminant();
         } catch (IllegalDimension e) {
             throw new RuntimeException(e.getMessage());
         }
@@ -458,7 +448,7 @@ public class MultivariateNormalDistribution implements MultivariateDistribution,
         double[] stop = {0, 0};
         double[][] precision = {{2, 0.5}, {0.5, 1}};
         double scale = 0.2;
-        System.err.println("logPDF = " + logPdf(start, stop, precision, Math.log(calculatePrecisionMatrixDeterminate(precision)), scale));
+        System.err.println("logPDF = " + logPdf(start, stop, precision, calculatePrecisionMatrixLogDeterminate(precision), scale));
         System.err.println("Should = -19.94863\n");
 
         System.err.println("logPDF = " + logPdf(start, stop, 2, 0.2));

--- a/src/dr/math/distributions/MultivariateNormalDistribution.java
+++ b/src/dr/math/distributions/MultivariateNormalDistribution.java
@@ -91,7 +91,8 @@ public class MultivariateNormalDistribution implements MultivariateDistribution,
 
     public double getLogDet() {
         if (logDet == null) {
-            logDet = Math.log(calculatePrecisionMatrixDeterminate(precision));
+            boolean inlogScale = true;
+            logDet = calculatePrecisionMatrixDeterminate(precision, inlogScale);
         }
         if (Double.isInfinite(logDet)) {
             if (isDiagonal(precision)) {
@@ -147,10 +148,24 @@ public class MultivariateNormalDistribution implements MultivariateDistribution,
         nextMultivariateNormalCholesky(mean, getCholeskyDecomposition(), Math.sqrt(scale), result);
     }
 
-
     public static double calculatePrecisionMatrixDeterminate(double[][] precision) {
+        boolean inLogScale = false;
+        return calculatePrecisionMatrixDeterminate(precision, inLogScale);
+    }
+
+    public static double calculatePrecisionMatrixDeterminate(double[][] precision, boolean inLogScale) {
         try {
-            return new Matrix(precision).determinant();
+            if (inLogScale) {
+                double logDet = 0;
+                double[][] L = getCholeskyDecomposition(precision);
+                for (int i = 0; i < L[0].length; ++i) {
+                    logDet += Math.log(L[i][i]);
+                }
+                logDet *= 2.0;
+                return logDet;
+            } else {
+                return new Matrix(precision).determinant();
+            }
         } catch (IllegalDimension e) {
             throw new RuntimeException(e.getMessage());
         }

--- a/src/dr/math/distributions/MultivariateNormalDistribution.java
+++ b/src/dr/math/distributions/MultivariateNormalDistribution.java
@@ -156,13 +156,7 @@ public class MultivariateNormalDistribution implements MultivariateDistribution,
     public static double calculatePrecisionMatrixDeterminate(double[][] precision, boolean inLogScale) {
         try {
             if (inLogScale) {
-                double logDet = 0;
-                double[][] L = getCholeskyDecomposition(precision);
-                for (int i = 0; i < L[0].length; ++i) {
-                    logDet += Math.log(L[i][i]);
-                }
-                logDet *= 2.0;
-                return logDet;
+                return new Matrix(precision).logDeterminant();
             } else {
                 return new Matrix(precision).determinant();
             }


### PR DESCRIPTION
Within the `MultivariateNormalDistribution` class, the precision matrix determinant was previously computed in the original scale and then plugged into `Math.log()`. This is prone to numerical overflow/underflow. Since almost all the use cases only required the calculation in log-scale, I've introduced a `calculatePrecisionMatrixLogDeterminate()` function in place of the `calculatePrecisionMatrixDeterminate()`. 

Where the determinant in the original scale is required --- IntelliJ found one such instance in the codebase --- I combined the log-scale calculation with `Math.exp()`: https://github.com/beast-dev/beast-mcmc/commit/d8bd23611ccd968862f6eca5afd5525f6101f41b#diff-ddfb0d5cc57fdf6e5601109205ecce65686115af607897069e36b39eb57acd48R152.

Incidentally, I decided to make use of the existing `logDeterminant()` function from the `Matrix` class, but it would be more efficient (half the number of flops) to use the Cholesky-based calculation for positive definite matrices: https://github.com/beast-dev/beast-mcmc/commit/88ad12803c7e360dce5b119ac482807a79e41ea9#diff-7a43dd7063e2b4b25168bd8a20b0bdd2beefdacdb855cd0286591c24d27c3ee0R159-R165.