### PR TITLE
Fix BEAST not checkpointing using the BEAUti checkpoint XML block

### DIFF
--- a/src/dr/app/beast/BeastMain.java
+++ b/src/dr/app/beast/BeastMain.java
@@ -168,6 +168,15 @@ public class BeastMain {
             // Install the checkpointer. This creates a factory that returns
             // appropriate savers and loaders according to the user's options.
             //new BeastCheckpointer();
+
+            // if any of these properties is not null, overrule XML checkpointing settings
+            if (System.getProperty("save.state.file", null) != null ||
+                    System.getProperty("save.state.at", null) != null ||
+                    System.getProperty("save.state.every", null) != null ||
+                    System.getProperty("save.state.time", null) != null) {
+                System.setProperty("checkpointOverrule","true");
+            }
+
             if (Boolean.parseBoolean(System.getProperty("checkpointOverrule", "false"))) {
                 BeastCheckpointer.getInstance(null, -1, -1, false);
                 Logger.getLogger("dr.apps.beast").info("Overriding checkpointing settings in the provided XML file");

--- a/src/dr/app/beast/BeastMain.java
+++ b/src/dr/app/beast/BeastMain.java
@@ -168,7 +168,7 @@ public class BeastMain {
             // Install the checkpointer. This creates a factory that returns
             // appropriate savers and loaders according to the user's options.
             //new BeastCheckpointer();
-            if (Boolean.parseBoolean(System.getProperty("checkpointOverrule", "true"))) {
+            if (Boolean.parseBoolean(System.getProperty("checkpointOverrule", "false"))) {
                 BeastCheckpointer.getInstance(null, -1, -1, false);
                 Logger.getLogger("dr.apps.beast").info("Overriding checkpointing settings in the provided XML file");
             }

--- a/src/dr/app/beast/release_parsers.properties
+++ b/src/dr/app/beast/release_parsers.properties
@@ -1,7 +1,7 @@
 #
 # release_parsers.properties
 #
-# Copyright ï¿½ 2002-2024 the BEAST Development Team
+# Copyright © 2002-2024 the BEAST Development Team
 # http://beast.community/about
 #
 # This file is part of BEAST.

--- a/src/dr/app/beast/release_parsers.properties
+++ b/src/dr/app/beast/release_parsers.properties
@@ -1,7 +1,7 @@
 #
 # release_parsers.properties
 #
-# Copyright © 2002-2024 the BEAST Development Team
+# Copyright ï¿½ 2002-2024 the BEAST Development Team
 # http://beast.community/about
 #
 # This file is part of BEAST.
@@ -450,6 +450,7 @@ dr.inferencexml.loggers.MLLoggerParser
 dr.inferencexml.loggers.ColumnsParser
 
 dr.evomodelxml.tree.TreeLoggerParser
+dr.inferencexml.loggers.CheckpointLoggerParser
 
 # TRACE ANALYSIS
 dr.evomodelxml.TreeTraceAnalysisParser

--- a/src/dr/app/checkpoint/BeastCheckpointer.java
+++ b/src/dr/app/checkpoint/BeastCheckpointer.java
@@ -181,8 +181,10 @@ public class BeastCheckpointer implements StateLoaderSaver {
     @Override
     public boolean saveState(MarkovChain markovChain, long state, double lnL) {
         String fileName = "";
-        if (stemFileName != null) {
+        if (stemFileName != null && this.saveStateFileName == null) {
             fileName = stemFileName + "_" + state;
+        } else if (stemFileName != null) {
+            fileName = stemFileName + "_" + this.saveStateFileName;
         } else {
             String timeStamp = new SimpleDateFormat("yyyy.MM.dd.HH.mm.ss").format(Calendar.getInstance().getTime());
             fileName = (this.saveStateFileName != null ? this.saveStateFileName : "beast_state_" + timeStamp);

--- a/src/dr/app/checkpoint/BeastCheckpointer.java
+++ b/src/dr/app/checkpoint/BeastCheckpointer.java
@@ -111,10 +111,10 @@ public class BeastCheckpointer implements StateLoaderSaver {
 
         } else {
 
-            loadStateFileName = null;
+            loadStateFileName = System.getProperty(LOAD_STATE_FILE, null);
             saveStateFileName = checkpointFileName;
 
-            stemFileName = null;
+            stemFileName = System.getProperty(SAVE_STEM, null);
 
             listeners.add(new StateSaverChainListener(BeastCheckpointer.this, checkpointFinal,false));
             listeners.add(new StateSaverChainListener(BeastCheckpointer.this, checkpointEvery,true));


### PR DESCRIPTION
Fix for the issue of BEAST not generating any checkpoint files if specified via XML.

To test this, I used the `YFV.xml` example file and added the following checkpointing logger in the mcmc block

```xml 
<!-- write state of Markov chain to checkpoint file                          -->
<logCheckpoint id="checkpointFileLog" checkpointEvery="100000" checkpointFinal="500000" fileName="YFV.chkpt" overwrite="false"/>
```

## PROBLEM: current behavior

Currently BEAST does not generate any checkpoint files from the BEAUTi XML because:

1. `release_parsers.properties` does not have `CheckpointLoggerParser`

2. The `checkpointOverrule` variable is always set to `true` in BeastMain

```java
 if (Boolean.parseBoolean(System.getProperty("checkpointOverrule", "true"))) {
  BeastCheckpointer.getInstance(null, -1, -1, false);
  Logger.getLogger("dr.apps.beast").info("Overriding checkpointing settings in the provided XML file");
}
```

## Fixing the XML checkpointing

To make BEAST use the checkpointing settings in the XML I did the following:

1. Add missing `CheckpointLoggerParser` to `release_parsers.properties`
2. Set default `checkpointOverrule` property to `false` in BeastMain:
	```java
	if (Boolean.parseBoolean(System.getProperty("checkpointOverrule", "false"))) {
	```

### Fixing the fix

Changing the default to `false` opens up a new problem, because the checkpoint overrule needs to now be set to `true` when the appropriate flags are passed in the command line. So we need to decide on which command line options/flags would result in overruling the XML checkpointing

Below are all of the checkpointing related options and flags I found in BeastMain:

```
-load_state
-save_stem
-save_at
-save_time
-save_every
-save_state
-full_checkpoint_precision
-force_resume
```

`-full_checkpoint_precision` and `-force_resume` shouldn't overrule the XML settings because they are not specified in the XML block, so I didn't do anything with them.

`-load_state` and `-save_stem` should not overrule the XML settings so that one can resume a run from the command line without changing anything. However, they were being ignored and BEAST would always start from scratch with the XML settings instead (would not load the file nor add a checkpoint file stem).

To fix this behavior, I changed the following variables from `null` in the else block of the `BeastCheckpointer` constructor:

```java
loadStateFileName = System.getProperty(LOAD_STATE_FILE, null);
stemFileName = System.getProperty(SAVE_STEM, null);
```

Additionally, I modified the `saveState` method in `BeastCheckpointer.java` so that it adds the stem to the checkpoint file name if it exists. The previous version was always saving to a new checkpoint file with name `<save stem>_<state number>`:

```java
public boolean saveState(MarkovChain markovChain, long state, double lnL) {
	String fileName = "";
	if (stemFileName != null && this.saveStateFileName == null) {
		fileName = stemFileName + "_" + state;
	} else if (stemFileName != null) {
		fileName = stemFileName + "_" + this.saveStateFileName;
	} else {
	...
```


Thus, I made it so that if any of the remaining options is set, we override the XML specification:
```
-save_at
-save_time
-save_every
-save_state
```

Doing this I was able to successfully do the following:

* Run BEAST from scratch and have it checkpoint using the XML settings
* Resume a BEAST run from a checkpoint using `-load_state <chkp> -save_stem <stem>` and  have it continue checkpointing using the frequency and filename in the XML settings
* Run BEAST from scratch overriding the XML checkpointing and checkpoint using command line options
* Resume a BEAST while overriding settings
