### PR TITLE
Solved an compile error caused by TreeAnnotator.java

### DIFF
--- a/src/dr/app/tools/treeannotator/TreeAnnotator.java
+++ b/src/dr/app/tools/treeannotator/TreeAnnotator.java
@@ -648,8 +648,8 @@ public class TreeAnnotator extends BaseTreeTool {
                 treeCladeCount);
         if (treeCladeCount < allCladeCount) {
             if (extendedMetrics) {
-                Set<Clade> treeClades = cladeSystem.getTopClades(tree, threshold);
-                Set<Clade> allClades = cladeSystem.getTopClades(threshold);
+                Set<BiClade> treeClades = cladeSystem.getTopClades(tree, threshold);
+                Set<BiClade> allClades = cladeSystem.getTopClades(threshold);
 
                 Set<Clade> missingClades = new HashSet<>(allClades);
                 missingClades.removeAll(treeClades);


### PR DESCRIPTION
**Problem**: When attempting to build the project using `ant build`, the compilation failed with **Type Incompatibility Errors** - In TreeAnnotator.java, the method `cladeSystem.getTopClades()` returned a `Set<BiClade>`, but the code attempted to assign it to a `Set<Clade>`, causing a generic type mismatch.

**Solution**: Fixed type incompatibility by modifying variable declarations to use `Set<BiClade>` instead of `Set<Clade>`.