### PR TITLE
Use absolute file path for checkpoints specified in XML

### DIFF
--- a/src/dr/inferencexml/loggers/CheckpointLoggerParser.java
+++ b/src/dr/inferencexml/loggers/CheckpointLoggerParser.java
@@ -47,7 +47,7 @@ public class CheckpointLoggerParser extends AbstractXMLObjectParser {
      * @return an object based on the XML element it was passed.
      */
     public Object parseXMLObject(XMLObject xo) throws XMLParseException {
-        final String fileName = xo.getStringAttribute(FILE_NAME);
+        final String fileName = FileHelpers.getFile(xo.getStringAttribute(FILE_NAME)).getAbsolutePath();
 
         final int checkpointEvery = xo.getIntegerAttribute(CHECKPOINT_EVERY);
 


### PR DESCRIPTION
Checkpoint files specified in the XML were passed as relative paths. In the macOS GUI, these paths resolved to the app launch directory rather than the XML directory, resulting in no checkpoint files generated.

Fix: CheckpointLoggerParser now uses the XML absolute path.